### PR TITLE
Decode escaped chars in spotify playlist description

### DIFF
--- a/package.json
+++ b/package.json
@@ -18,6 +18,7 @@
     "@types/spotify-web-playback-sdk": "^0.1.8",
     "@types/styled-components": "^5.1.9",
     "framer-motion": "^4.0.3",
+    "he": "^1.2.0",
     "long-press-event": "^2.4.4",
     "react": "^17.0.1",
     "react-dom": "^17.0.1",
@@ -49,6 +50,7 @@
   },
   "devDependencies": {
     "@types/apple-music-api": "^0.4.0",
+    "@types/he": "^1.1.1",
     "@types/spotify-api": "^0.0.8"
   }
 }

--- a/src/utils/conversion.ts
+++ b/src/utils/conversion.ts
@@ -1,3 +1,5 @@
+import { decode } from 'he'
+
 // Artwork Conversion
 
 /** Accepts a url with '{w}' and '{h}' and replaces them with the specified size */
@@ -68,7 +70,7 @@ export const convertSpotifyPlaylistSimplified = (
   curatorName: data.owner.display_name ?? '',
   url: data.uri,
   artwork: { url: data.images[0]?.url ?? '' },
-  description: data.description ?? '',
+  description: data.description ? decode(data.description) : '',
   songs: [],
 });
 


### PR DESCRIPTION
Spotify escapes certain characters (e.g. `' " /`) when it returns playlist descriptions from its api. This PR adds the he package as a dependency to decode playlist descriptions.

<img width="390" alt="Screen Shot 2021-06-23 at 7 10 29 PM" src="https://user-images.githubusercontent.com/405000/123139648-6e566900-d424-11eb-9741-b2e6fecc8128.png">

Notes:
- In order to run `yarn` I had to remove the `yarn.lock` file locally because its [resolved urls](https://github.com/tvillarete/ipod-classic-js/blob/master/yarn.lock#L7) point to convoy's artifactory instance which I don't have access to. I haven't updated the `yarn.lock` in this PR for that reason.
- I also wasn't able to fully test this locally because I don't have an apple developer token.