### PR TITLE
Adding utilities for creating type-safe events for the iPod

### DIFF
--- a/src/components/Controls/Scrubber.tsx
+++ b/src/components/Controls/Scrubber.tsx
@@ -7,6 +7,7 @@ import { formatTime } from 'utils';
 import { Unit } from 'utils/constants';
 
 import ProgressBar from './ProgressBar';
+import { IpodEvent } from 'utils/events';
 
 const Container = styled.div`
   position: relative;
@@ -86,8 +87,8 @@ const Scrubber = ({ isScrubbing }: Props) => {
     [currentTime, isActive, isPlaying]
   );
 
-  useEventListener('forwardscroll', scrubForward);
-  useEventListener('backwardscroll', scrubBackward);
+  useEventListener<IpodEvent>('forwardscroll', scrubForward);
+  useEventListener<IpodEvent>('backwardscroll', scrubBackward);
 
   /** Update the progress bar every second. */
   useInterval(refresh, 1000);

--- a/src/components/Controls/index.tsx
+++ b/src/components/Controls/index.tsx
@@ -5,11 +5,9 @@ import styled from 'styled-components';
 import { Unit } from 'utils/constants';
 
 import Scrubber from './Scrubber';
-// import Scrubber from './Scrubber';
 import TrackProgress from './TrackProgress';
 import VolumeBar from './VolumeBar';
-
-// import VolumeBar from './VolumeBar';
+import { IpodEvent } from 'utils/events';
 
 const Container = styled.div`
   position: relative;
@@ -59,7 +57,7 @@ const Controls = () => {
     }
   }, [isScrubbing, setEnabled]);
 
-  useEventListener('centerclick', handleCenterClick);
+  useEventListener<IpodEvent>('centerclick', handleCenterClick);
 
   return (
     <Container>

--- a/src/components/ScrollWheel/index.tsx
+++ b/src/components/ScrollWheel/index.tsx
@@ -3,6 +3,7 @@ import { useCallback, useRef, useState } from 'react';
 import { useEffectOnce, useEventListener } from 'hooks';
 
 import Knob from './Knob';
+import { createIpodEvent } from 'utils/events';
 
 enum WHEEL_QUADRANT {
   TOP = 1,
@@ -11,27 +12,27 @@ enum WHEEL_QUADRANT {
   RIGHT = 4,
 }
 
-enum KEY_CODE {
-  ARROW_UP = 38,
-  ARROW_DOWN = 40,
-  ARROW_LEFT = 37,
-  ARROW_RIGHT = 39,
-  ESC = 27,
-  ENTER = 13,
-  SPACE = 32,
-}
+type SupportedKeyCode =
+  | 'ArrowUp'
+  | 'ArrowDown'
+  | 'ArrowLeft'
+  | 'ArrowRight'
+  | 'Escape'
+  | 'Enter'
+  | ' '
+  | 'Spacebar'
 
-const centerClickEvent = new Event('centerclick');
-const centerLongClickEvent = new Event('centerlongclick');
-const forwardScrollEvent = new Event('forwardscroll');
-const backwardScrollEvent = new Event('backwardscroll');
-const wheelClickEvent = new Event('wheelclick');
-const menuClickEvent = new Event('menuclick');
-const menuLongPressEvent = new Event('menulongpress');
-const backClickEvent = new Event('backclick');
-const forwardClickEvent = new Event('forwardclick');
-const playPauseClickEvent = new Event('playpauseclick');
-const idleEvent = new Event('idle');
+const centerClickEvent = createIpodEvent('centerclick');
+const centerLongClickEvent = createIpodEvent('centerlongclick');
+const forwardScrollEvent = createIpodEvent('forwardscroll');
+const backwardScrollEvent = createIpodEvent('backwardscroll');
+const wheelClickEvent = createIpodEvent('wheelclick');
+const menuClickEvent = createIpodEvent('menuclick');
+const menuLongPressEvent = createIpodEvent('menulongpress');
+const backClickEvent = createIpodEvent('backwardclick');
+const forwardClickEvent = createIpodEvent('forwardclick');
+const playPauseClickEvent = createIpodEvent('playpauseclick');
+const idleEvent = createIpodEvent('idle');
 
 const ScrollWheel = () => {
   const [count, setCount] = useState(0);
@@ -96,22 +97,23 @@ const ScrollWheel = () => {
   /** Allows for keyboard navigation. */
   const handleKeyPress = useCallback(
     (event: React.KeyboardEvent<HTMLDivElement>) => {
-      switch (event.keyCode) {
-        case KEY_CODE.ARROW_UP:
-        case KEY_CODE.ARROW_LEFT:
+      switch (event.key as SupportedKeyCode) {
+        case 'ArrowUp':
+        case 'ArrowLeft':
           handleCounterClockwiseScroll();
           break;
-        case KEY_CODE.ARROW_DOWN:
-        case KEY_CODE.ARROW_RIGHT:
+        case 'ArrowDown':
+        case 'ArrowRight':
           handleClockwiseScroll();
           break;
-        case KEY_CODE.ENTER:
+        case 'Enter':
           handleCenterClick();
           break;
-        case KEY_CODE.SPACE:
+        case ' ':
+        case 'Spacebar':
           handleWheelClick(WHEEL_QUADRANT.BOTTOM);
           break;
-        case KEY_CODE.ESC:
+        case 'Escape':
           handleWheelClick(WHEEL_QUADRANT.TOP);
           break;
       }

--- a/src/components/WindowManager/components/ActionSheet.tsx
+++ b/src/components/WindowManager/components/ActionSheet.tsx
@@ -13,6 +13,7 @@ import {
 import { WindowOptions } from 'providers/WindowProvider';
 import styled, { css } from 'styled-components';
 import { Unit } from 'utils/constants';
+import { IpodEvent } from 'utils/events';
 
 interface RootContainerProps {
   index: number;
@@ -105,12 +106,12 @@ const ActionSheet = ({ windowStack, index, isHidden }: Props) => {
       {
         type: 'Action',
         label: 'Cancel',
-        onSelect: () => {},
+        onSelect: () => { },
       },
     ];
   }, [windowOptions]);
 
-  useEventListener('centerclick', () => {
+  useEventListener<IpodEvent>('centerclick', () => {
     hideWindow();
   });
 

--- a/src/components/WindowManager/components/Popup.tsx
+++ b/src/components/WindowManager/components/Popup.tsx
@@ -13,13 +13,14 @@ import {
 import { WindowOptions } from 'providers/WindowProvider';
 import styled, { css } from 'styled-components';
 import { Unit } from 'utils/constants';
+import { IpodEvent } from 'utils/events';
 
 interface RootContainerProps {
   index: number;
 }
 
 /** Responsible for putting the window at the proper z-index. */
-export const RootContainer = styled(motion.div)<RootContainerProps>`
+export const RootContainer = styled(motion.div) <RootContainerProps>`
   z-index: ${(props) => props.index};
   position: absolute;
   top: 0;
@@ -118,17 +119,17 @@ const Popup = ({ windowStack, index, isHidden }: Props) => {
     return listOptions.length
       ? listOptions
       : [
-          {
-            type: 'Action',
-            label: 'Done',
-            onSelect: () => {},
-          },
-        ];
+        {
+          type: 'Action',
+          label: 'Done',
+          onSelect: () => { },
+        },
+      ];
   }, [windowOptions.listOptions, windowOptions.type]);
 
   const [scrollIndex] = useScrollHandler(windowOptions.id, listOptions);
 
-  useEventListener('centerclick', () => {
+  useEventListener<IpodEvent>('centerclick', () => {
     hideWindow();
   });
 

--- a/src/components/WindowManager/index.tsx
+++ b/src/components/WindowManager/index.tsx
@@ -2,6 +2,7 @@ import { ErrorScreen } from 'components';
 import { WINDOW_TYPE } from 'components/views';
 import { useEventListener, useMusicKit, useWindowContext } from 'hooks';
 import styled from 'styled-components';
+import { IpodEvent } from 'utils/events';
 
 import ActionSheetWindowManager from './ActionSheetWindowManager';
 import CoverFlowWindowManager from './CoverFlowWindowManager';
@@ -40,7 +41,7 @@ const WindowManager = () => {
 
   const isReady = isConfigured && hasAppleDevToken;
 
-  useEventListener('menulongpress', resetWindows);
+  useEventListener<IpodEvent>('menulongpress', resetWindows);
 
   return (
     <div>

--- a/src/components/views/CoverFlowView/BacksideContent.tsx
+++ b/src/components/views/CoverFlowView/BacksideContent.tsx
@@ -9,6 +9,7 @@ import { useDataFetcher, useEventListener, useScrollHandler } from 'hooks';
 import styled from 'styled-components';
 
 import ViewOptions from '../';
+import { IpodEvent } from 'utils/events';
 
 const Container = styled.div`
   position: absolute;
@@ -71,7 +72,7 @@ const BacksideContent = ({ albumId, setPlayingAlbum }: Props) => {
   );
   const [scrollIndex] = useScrollHandler(ViewOptions.coverFlow.id, options);
 
-  useEventListener('centerclick', () => setPlayingAlbum(true));
+  useEventListener<IpodEvent>('centerclick', () => setPlayingAlbum(true));
 
   return (
     <Container>

--- a/src/components/views/CoverFlowView/CoverFlow.tsx
+++ b/src/components/views/CoverFlowView/CoverFlow.tsx
@@ -7,6 +7,7 @@ import { useEventListener, useWindowContext } from 'hooks';
 import styled from 'styled-components';
 
 import AlbumCover from './AlbumCover';
+import { IpodEvent } from 'utils/events';
 
 export type Point = {
   x: number;
@@ -109,10 +110,10 @@ const CoverFlow = ({ albums }: Props) => {
 
   useEffect(updateMidpoint, [updateMidpoint]);
 
-  useEventListener('centerclick', selectAlbum);
-  useEventListener('menuclick', handleMenuClick);
-  useEventListener('forwardscroll', forwardScroll);
-  useEventListener('backwardscroll', backwardScroll);
+  useEventListener<IpodEvent>('centerclick', selectAlbum);
+  useEventListener<IpodEvent>('menuclick', handleMenuClick);
+  useEventListener<IpodEvent>('forwardscroll', forwardScroll);
+  useEventListener<IpodEvent>('backwardscroll', backwardScroll);
 
   return (
     <Container>

--- a/src/components/views/CoverFlowView/index.tsx
+++ b/src/components/views/CoverFlowView/index.tsx
@@ -10,6 +10,7 @@ import {
 import styled from 'styled-components';
 
 import CoverFlow from './CoverFlow';
+import { IpodEvent } from 'utils/events';
 
 const Container = styled.div`
   flex: 1;
@@ -29,7 +30,7 @@ const CoverFlowView = () => {
     }
   }, [hideWindow, isAuthorized, isLoading]);
 
-  useEventListener('menuclick', handleMenuClick);
+  useEventListener<IpodEvent>('menuclick', handleMenuClick);
 
   return (
     <Container>

--- a/src/components/views/HomeView/index.tsx
+++ b/src/components/views/HomeView/index.tsx
@@ -24,6 +24,7 @@ import {
   useSpotifySDK,
   useWindowContext,
 } from 'hooks';
+import { IpodEvent } from 'utils/events';
 
 const strings = {
   nowPlaying: 'Now Playing',
@@ -115,7 +116,7 @@ const HomeView = () => {
     }
   }, [nowPlayingItem, showWindow, windowStack]);
 
-  useEventListener('idle', handleIdleState);
+  useEventListener<IpodEvent>('idle', handleIdleState);
 
   return <SelectableList options={options} activeIndex={scrollIndex} />;
 };

--- a/src/hooks/audio/useAudioPlayer.tsx
+++ b/src/hooks/audio/useAudioPlayer.tsx
@@ -308,9 +308,9 @@ export const AudioPlayerProvider = ({ children }: Props) => {
         duration: music.player.currentPlaybackDuration,
       }));
     } else if (service === 'spotify') {
-      const { position, duration } = await spotifyPlayer.getCurrentState() ?? { position: 0, duration: 0 };
-      const currentTime = position / 1000;
-      const maxTime = duration / 1000;
+      const { position, duration } = await spotifyPlayer.getCurrentState() ?? {};
+      const currentTime = (position ?? 0) / 1000;
+      const maxTime = (duration ?? 0) / 1000;
       const timeRemaining = maxTime - currentTime;
       const percent = Math.round((currentTime / maxTime) * 100);
 

--- a/src/hooks/audio/useVolumeHandler.ts
+++ b/src/hooks/audio/useVolumeHandler.ts
@@ -1,4 +1,5 @@
 import { useCallback, useRef, useState } from 'react';
+import { IpodEvent } from 'utils/events';
 
 import { useAudioPlayer, useEffectOnce, useEventListener } from '../';
 
@@ -67,10 +68,10 @@ const useVolumeHandler = (): VolumeHandlerHook => {
     setVolume(newVolume);
   }, [setActiveState, volume, enabled, setVolume]);
 
-  useEventListener('forwardscroll', increaseVolume);
-  useEventListener('backwardscroll', decreaseVolume);
+  useEventListener<IpodEvent>('forwardscroll', increaseVolume);
+  useEventListener<IpodEvent>('backwardscroll', decreaseVolume);
   /** Don't mistake a scroll for a click. */
-  useEventListener('wheelclick', () => setActive(false));
+  useEventListener<IpodEvent>('wheelclick', () => setActive(false));
 
   return {
     setEnabled,

--- a/src/hooks/navigation/useMenuHideWindow.ts
+++ b/src/hooks/navigation/useMenuHideWindow.ts
@@ -3,6 +3,7 @@ import { useCallback } from 'react';
 import { useWindowContext } from 'hooks';
 
 import useEventListener from '../utils/useEventListener';
+import { IpodEvent } from 'utils/events';
 
 /**
  * A quick way to use the menu button as a back button.
@@ -17,7 +18,7 @@ const useMenuHideWindow = (id: string) => {
     }
   }, [hideWindow, id, windowStack]);
 
-  useEventListener('menuclick', handleClick);
+  useEventListener<IpodEvent>('menuclick', handleClick);
 };
 
 export default useMenuHideWindow;

--- a/src/hooks/navigation/useScrollHandler.tsx
+++ b/src/hooks/navigation/useScrollHandler.tsx
@@ -9,6 +9,7 @@ import ViewOptions, { NowPlayingView, WINDOW_TYPE } from 'components/views';
 import { useWindowContext } from 'hooks';
 
 import { useAudioPlayer, useEffectOnce, useEventListener } from '../';
+import { IpodEvent } from 'utils/events';
 
 /** Accepts a list of options and will maintain a scroll index capped at the list's length. */
 const useScrollHandler = (
@@ -20,7 +21,7 @@ const useScrollHandler = (
   const { showWindow, windowStack, setPreview } = useWindowContext();
   const { play } = useAudioPlayer();
   const [index, setIndex] = useState(0);
-  const timeoutIdRef = useRef<any>();
+  const timeoutIdRef = useRef<NodeJS.Timeout>();
   /** Only fire events on the top-most view. */
   const isActive = windowStack[windowStack.length - 1].id === id;
 
@@ -173,12 +174,10 @@ const useScrollHandler = (
     }
   });
 
-  useEventListener('centerclick', () => {
-    handleCenterClick();
-  });
-  useEventListener('centerlongclick', handleCenterLongClick);
-  useEventListener('forwardscroll', handleForwardScroll);
-  useEventListener('backwardscroll', handleBackwardScroll);
+  useEventListener<IpodEvent>('centerclick', handleCenterClick);
+  useEventListener<IpodEvent>('centerlongclick', handleCenterLongClick);
+  useEventListener<IpodEvent>('forwardscroll', handleForwardScroll);
+  useEventListener<IpodEvent>('backwardscroll', handleBackwardScroll);
 
   return [index];
 };

--- a/src/hooks/utils/useEventListener.ts
+++ b/src/hooks/utils/useEventListener.ts
@@ -1,8 +1,8 @@
 import { useRef, useEffect } from "react";
 
 // Hook
-const useEventListener = (
-  eventName: string,
+const useEventListener = <TEvent extends string>(
+  eventName: TEvent,
   handler: (...args: any) => void,
   element = window
 ) => {

--- a/src/utils/events.ts
+++ b/src/utils/events.ts
@@ -1,0 +1,11 @@
+/** The click-wheel control associated with the particular event */
+type BaseEventContext = 'wheel' | 'center' | 'forward' | 'backward' | 'menu' | 'playpause';
+
+/** The action that is taken on a click-wheel control */
+type BaseEventAction = 'click' | 'longclick' | 'scroll' | 'longpress';
+
+/** The custom events that are supported for the iPod */
+export type IpodEvent = `${BaseEventContext}${BaseEventAction}` | `idle`
+
+/** Create a type-safe custom event for the iPod */
+export const createIpodEvent = (eventName: IpodEvent) => new Event(eventName);


### PR DESCRIPTION
- Adding a `createIpodEvent` helper, which will provide improved type-safety for creating custom events
- Adding an `IpodEvent` type, which describes the possible event names for the custom events
- Updated `useEventListener` to use generic types, so we can put constraints on the event names that are passed to it
- Updated existing usage of `useEventListener` for custom events to use `IpodEvent` type