### PR TITLE
Update README.md to add note about Apple Dev Token

### DIFF
--- a/README.md
+++ b/README.md
@@ -19,6 +19,9 @@ Here's a breakdown of the Full Stack:
 
 ## Running Locally
 
+#### NOTE
+If you want to develop locally with this project, you'll need to supply an Apple Developer Token using the `token` query parameter. See https://developer.apple.com/documentation/applemusicapi/getting_keys_and_creating_tokens
+
 In the project directory, you can run:
 
 ### `yarn start`


### PR DESCRIPTION
It wasn't entirely clear that in order to use this project locally you'll need to supply a dev token via query params. I'll improve this later, but it should at least be present.