### PR TITLE
Header: Add margin-left to battery indicator

### DIFF
--- a/src/components/BatteryIndicator/index.tsx
+++ b/src/components/BatteryIndicator/index.tsx
@@ -71,7 +71,7 @@ const IconContainer = styled.div`
 `;
 
 const StatusIcon = styled.img`
-  opacity: .8;
+  opacity: 0.8;
 `;
 
 const BoltIcon = styled(StatusIcon)`
@@ -82,7 +82,11 @@ const PlugIcon = styled(StatusIcon)`
   height: 6px;
 `;
 
-const BatteryIndicator = () => {
+interface Props {
+  className?: string;
+}
+
+const BatteryIndicator = ({ className }: Props) => {
   const { chargePercent, isCharging } = useBattery();
 
   const clampedChargePercent = chargePercent <= 15 ? 15 : chargePercent;
@@ -91,11 +95,11 @@ const BatteryIndicator = () => {
   const shouldShowBoltIcon = isCharging && chargePercent < 100;
 
   return (
-    <Container>
+    <Container className={className}>
       <ChargeLevelContainer>
         <IconContainer>
-          { shouldShowPlugIcon ? <PlugIcon src="plug.svg" /> : null }
-          { shouldShowBoltIcon ? <BoltIcon src="bolt.svg" /> : null }
+          {shouldShowPlugIcon && <PlugIcon src="plug.svg" />}
+          {shouldShowBoltIcon && <BoltIcon src="bolt.svg" />}
         </IconContainer>
         <ChargeLevel percent={clampedChargePercent} isCharging={isCharging} />
       </ChargeLevelContainer>

--- a/src/components/Header/index.tsx
+++ b/src/components/Header/index.tsx
@@ -32,6 +32,10 @@ const Icon = styled.img`
   margin-left: 8px;
 `;
 
+const StyledBatteryIndicator = styled(BatteryIndicator)`
+  margin-left: 8px;
+`;
+
 const Header = () => {
   const { headerTitle } = useWindowContext();
   const { playbackInfo } = useAudioPlayer();
@@ -49,7 +53,7 @@ const Header = () => {
         )}
         {isPlaying && !isPaused && <Icon src="play.svg" />}
         {isPaused && <Icon src="pause.svg" />}
-        <BatteryIndicator />
+        <StyledBatteryIndicator />
       </IconContainer>
     </Container>
   ) : null;


### PR DESCRIPTION
The indicator and play button were getting scrunched together. This pull fixes that issue:

<img width="185" alt="Screen Shot 2021-06-26 at 11 36 58 AM" src="https://user-images.githubusercontent.com/21055469/123522574-dac6a780-d672-11eb-85dd-1a6bc374162a.png">
