### PR TITLE
MusicKit JS: Upgrade to V3

### DIFF
--- a/package.json
+++ b/package.json
@@ -9,6 +9,7 @@
     "he": "^1.2.0",
     "long-press-event": "^2.4.4",
     "prettier": "^2.3.1",
+    "query-string": "^7.0.1",
     "react": "^17.0.1",
     "react-dom": "^17.0.1",
     "react-scripts": "^4.0.3",

--- a/public/index.html
+++ b/public/index.html
@@ -2,7 +2,7 @@
 <html lang="en">
   <head>
     <!-- Global site tag (gtag.js) - Google Analytics -->
-    <script src="https://js-cdn.music.apple.com/musickit/v1/musickit.js"></script>
+    <script src="https://js-cdn.music.apple.com/musickit/v3/musickit.js"></script>
     <script
       async
       src="https://www.googletagmanager.com/gtag/js?id=UA-139077840-1"

--- a/src/hooks/audio/useAudioPlayer.tsx
+++ b/src/hooks/audio/useAudioPlayer.tsx
@@ -64,19 +64,28 @@ export const AudioPlayerProvider = ({ children }: Props) => {
         throw new Error('Unable to play: Not authorized');
       }
 
-      // MusicKit JS V3 expects only a single media type with no empty keys.
-      // We're filtering out any keys that are undefined.
+      /**
+       * MusicKit JS V3 doesn't seem to support passing in a single playlist id to the queue.
+       * A workaround is to just grab the song ids instead.
+       * */
+      const playlistSongs = queueOptions.playlist?.songs?.map(({ id }) => id);
+
+      /**
+       * MusicKit JS V3 expects only a single media type with no empty keys.
+       * We're filtering out any keys that are undefined.
+       *
+       * @example { album: 'a.12345', startPosition: 0 }
+       */
       const queue = Object.fromEntries(
         Object.entries({
           album: queueOptions.album?.id,
-          playlist: queueOptions.playlist?.id,
-          songs: queueOptions.songs?.map((song) => song.url),
+          songs: playlistSongs ?? queueOptions.songs?.map((song) => song.url),
           song: queueOptions.song?.id,
           startPosition: queueOptions.startPosition,
-        }).filter(([_, value]) => !!value)
+        }).filter(([_, value]) => value !== undefined)
       );
 
-      await music.setQueue(queue);
+      await music.setQueue({ ...queue });
 
       await music.play();
     },

--- a/src/hooks/audio/useAudioPlayer.tsx
+++ b/src/hooks/audio/useAudioPlayer.tsx
@@ -166,8 +166,10 @@ export const AudioPlayerProvider = ({ children }: Props) => {
 
     switch (service) {
       case 'apple':
+        // TODO: Update types for MusicKit V3
         if ((music as any).isPlaying) {
           music.pause();
+          // TODO: Update types for MusicKit V3
         } else if (!(music as any).isPlaying) {
           music.play();
         }
@@ -192,6 +194,7 @@ export const AudioPlayerProvider = ({ children }: Props) => {
 
     switch (service) {
       case 'apple':
+        // TODO: Update types for MusicKit V3
         if ((music as any).nowPlayingItem) {
           await music.skipToNextItem();
         }
@@ -221,6 +224,7 @@ export const AudioPlayerProvider = ({ children }: Props) => {
 
     switch (service) {
       case 'apple':
+        // TODO: Update types for MusicKit V3
         if ((music as any).nowPlayingItem) {
           await music.skipToPreviousItem();
         }
@@ -241,6 +245,7 @@ export const AudioPlayerProvider = ({ children }: Props) => {
   const updateNowPlayingItem = useCallback(async () => {
     let mediaItem: IpodApi.MediaItem | undefined;
 
+    // TODO: Update types for MusicKit V3
     if (service === 'apple' && (music as any).nowPlayingItem) {
       // TODO: Update types for MusicKit V3
       mediaItem = ConversionUtils.convertAppleMediaItem(
@@ -316,6 +321,7 @@ export const AudioPlayerProvider = ({ children }: Props) => {
     if (service === 'apple') {
       setPlaybackInfo((prevState) => ({
         ...prevState,
+        // TODO: Update types for MusicKit V3
         currentTime: (music as any).currentPlaybackTime,
         timeRemaining: (music as any).currentPlaybackTimeRemaining,
         percent: (music as any).currentPlaybackProgress * 100,
@@ -342,6 +348,7 @@ export const AudioPlayerProvider = ({ children }: Props) => {
   const seekToTime = useCallback(
     async (time: number) => {
       if (service === 'apple') {
+        // TODO: Update types for MusicKit V3
         await (music as any).player.seekToTime(time);
       } else if (service === 'spotify') {
         // Seek to time (in ms)
@@ -360,6 +367,7 @@ export const AudioPlayerProvider = ({ children }: Props) => {
       }
 
       if (isAppleAuthorized) {
+        // TODO: Update types for MusicKit V3
         (music as any).volume = newVolume;
       }
 

--- a/src/hooks/audio/useAudioPlayer.tsx
+++ b/src/hooks/audio/useAudioPlayer.tsx
@@ -8,9 +8,9 @@ import {
 
 import { useEventListener, useMKEventListener } from 'hooks';
 import * as ConversionUtils from 'utils/conversion';
+import { IpodEvent } from 'utils/events';
 
 import { useMusicKit, useSettings, useSpotifySDK, VOLUME_KEY } from '../';
-import { IpodEvent } from 'utils/events';
 
 const defaultPlatbackInfoState = {
   isPlaying: false,
@@ -64,16 +64,19 @@ export const AudioPlayerProvider = ({ children }: Props) => {
         throw new Error('Unable to play: Not authorized');
       }
 
-      await music.setQueue({
-        album: queueOptions.album?.id,
-        playlist: queueOptions.playlist?.id,
-        songs: queueOptions.songs?.map((song) => song.url),
-        song: queueOptions.song?.id,
-        // MusicKit has a weird issue where the start position needs to be subtracted by 1.
-        startPosition: queueOptions.startPosition
-          ? queueOptions.startPosition - 1
-          : undefined,
-      });
+      // MusicKit JS V3 expects only a single media type with no empty keys.
+      // We're filtering out any keys that are undefined.
+      const queue = Object.fromEntries(
+        Object.entries({
+          album: queueOptions.album?.id,
+          playlist: queueOptions.playlist?.id,
+          songs: queueOptions.songs?.map((song) => song.url),
+          song: queueOptions.song?.id,
+          startPosition: queueOptions.startPosition,
+        }).filter(([_, value]) => !!value)
+      );
+
+      await music.setQueue(queue);
 
       await music.play();
     },
@@ -154,9 +157,9 @@ export const AudioPlayerProvider = ({ children }: Props) => {
 
     switch (service) {
       case 'apple':
-        if (music.player.isPlaying) {
+        if ((music as any).isPlaying) {
           music.pause();
-        } else {
+        } else if (!(music as any).isPlaying) {
           music.play();
         }
         break;
@@ -180,7 +183,7 @@ export const AudioPlayerProvider = ({ children }: Props) => {
 
     switch (service) {
       case 'apple':
-        if (music.player.nowPlayingItem) {
+        if ((music as any).nowPlayingItem) {
           await music.skipToNextItem();
         }
         break;
@@ -209,7 +212,7 @@ export const AudioPlayerProvider = ({ children }: Props) => {
 
     switch (service) {
       case 'apple':
-        if (music.player.nowPlayingItem) {
+        if ((music as any).nowPlayingItem) {
           await music.skipToPreviousItem();
         }
         break;
@@ -229,9 +232,10 @@ export const AudioPlayerProvider = ({ children }: Props) => {
   const updateNowPlayingItem = useCallback(async () => {
     let mediaItem: IpodApi.MediaItem | undefined;
 
-    if (service === 'apple' && music.player.nowPlayingItem) {
+    if (service === 'apple' && (music as any).nowPlayingItem) {
+      // TODO: Update types for MusicKit V3
       mediaItem = ConversionUtils.convertAppleMediaItem(
-        music.player.nowPlayingItem
+        (music as any).nowPlayingItem
       );
     } else if (service === 'spotify') {
       const state = await spotifyPlayer.getCurrentState();
@@ -242,7 +246,7 @@ export const AudioPlayerProvider = ({ children }: Props) => {
     }
 
     setNowPlayingItem(mediaItem);
-  }, [music.player.nowPlayingItem, service, spotifyPlayer]);
+  }, [music, service, spotifyPlayer]);
 
   const handleApplePlaybackStateChange = useCallback(
     ({ state }: { state: MusicKit.PlaybackStates }) => {
@@ -303,10 +307,10 @@ export const AudioPlayerProvider = ({ children }: Props) => {
     if (service === 'apple') {
       setPlaybackInfo((prevState) => ({
         ...prevState,
-        currentTime: music.player.currentPlaybackTime,
-        timeRemaining: music.player.currentPlaybackTimeRemaining,
-        percent: music.player.currentPlaybackProgress * 100,
-        duration: music.player.currentPlaybackDuration,
+        currentTime: (music as any).currentPlaybackTime,
+        timeRemaining: (music as any).currentPlaybackTimeRemaining,
+        percent: (music as any).currentPlaybackProgress * 100,
+        duration: (music as any).currentPlaybackDuration,
       }));
     } else if (service === 'spotify') {
       const { position, duration } =
@@ -324,12 +328,12 @@ export const AudioPlayerProvider = ({ children }: Props) => {
         duration: maxTime,
       }));
     }
-  }, [music.player, service, spotifyPlayer]);
+  }, [music, service, spotifyPlayer]);
 
   const seekToTime = useCallback(
     async (time: number) => {
       if (service === 'apple') {
-        await music.player.seekToTime(time);
+        await (music as any).player.seekToTime(time);
       } else if (service === 'spotify') {
         // Seek to time (in ms)
         await spotifyPlayer.seek(time * 1000);
@@ -337,7 +341,7 @@ export const AudioPlayerProvider = ({ children }: Props) => {
 
       updatePlaybackInfo();
     },
-    [music.player, service, spotifyPlayer, updatePlaybackInfo]
+    [music, service, spotifyPlayer, updatePlaybackInfo]
   );
 
   const handleChangeVolume = useCallback(
@@ -347,14 +351,14 @@ export const AudioPlayerProvider = ({ children }: Props) => {
       }
 
       if (isAppleAuthorized) {
-        music.player.volume = newVolume;
+        (music as any).volume = newVolume;
       }
 
       localStorage.setItem(VOLUME_KEY, `${newVolume}`);
 
       setVolume(newVolume);
     },
-    [isAppleAuthorized, isSpotifyAuthorized, music.player, spotifyPlayer]
+    [isAppleAuthorized, isSpotifyAuthorized, music, spotifyPlayer]
   );
 
   useEventListener<IpodEvent>('playpauseclick', () => {

--- a/src/hooks/musicKit/index.ts
+++ b/src/hooks/musicKit/index.ts
@@ -1,3 +1,4 @@
 export * from './useMusicKit';
 
 export { default as useMKEventListener } from './useMKEventListener';
+export { default as useMKDataFetcher } from './useMKDataFetcher';

--- a/src/hooks/musicKit/useMKDataFetcher.ts
+++ b/src/hooks/musicKit/useMKDataFetcher.ts
@@ -1,0 +1,135 @@
+import { useCallback } from 'react';
+
+import { useMusicKit } from 'hooks';
+import queryString from 'query-string';
+import * as ConversionUtils from 'utils/conversion';
+
+type FetchAppleMusicApiArgs = {
+  endpoint: string;
+  params?: Record<string, string | number>;
+  inLibrary?: boolean;
+};
+
+/** Connects to the Apple Music API to return data to the UI. */
+const useMKDataFetcher = () => {
+  const { music } = useMusicKit();
+
+  const fetchAppleMusicApi = useCallback(
+    async <TApiResponseType extends object>({
+      endpoint,
+      inLibrary = false,
+      params = {},
+    }: FetchAppleMusicApiArgs) => {
+      const baseUrl = inLibrary
+        ? `/v1/me/library/${endpoint}`
+        : `/v1/catalog/{{storefrontId}}/${endpoint}`;
+      const paramsString = queryString.stringify(params);
+
+      const url = `${baseUrl}?${paramsString}`;
+
+      try {
+        // TODO: Update types for MusicKit V3
+        const response = await (music.api as any).music(url);
+
+        return response.data as TApiResponseType;
+      } catch (error) {
+        // TODO: Show a popup instead.
+        throw new Error(error);
+      }
+    },
+    [music.api]
+  );
+
+  const fetchAlbums = useCallback(async () => {
+    const response = await fetchAppleMusicApi<AppleMusicApi.AlbumResponse>({
+      endpoint: `/albums`,
+      inLibrary: true,
+      params: {
+        limit: 100,
+      },
+    });
+
+    if (response) {
+      return response.data.map((item: AppleMusicApi.Album) =>
+        ConversionUtils.convertAppleAlbum(item, 300)
+      );
+    }
+  }, [fetchAppleMusicApi]);
+
+  const fetchAlbum = useCallback(
+    async (id: string, inLibrary = false) => {
+      const response = await fetchAppleMusicApi<AppleMusicApi.AlbumResponse>({
+        endpoint: `albums/${id}`,
+        inLibrary,
+      });
+
+      if (response) {
+        return ConversionUtils.convertAppleAlbum(response.data[0]);
+      }
+    },
+    [fetchAppleMusicApi]
+  );
+
+  const fetchArtists = useCallback(async () => {
+    const response = await fetchAppleMusicApi<AppleMusicApi.ArtistResponse>({
+      endpoint: `/artists`,
+      inLibrary: true,
+    });
+
+    return response.data.map(ConversionUtils.convertAppleArtist);
+  }, [fetchAppleMusicApi]);
+
+  const fetchArtistAlbums = useCallback(
+    async (id: string, inLibrary = false) => {
+      const response = await fetchAppleMusicApi<AppleMusicApi.AlbumResponse>({
+        endpoint: `/artists/${id}/albums`,
+        inLibrary,
+      });
+
+      return response.data.map((item: AppleMusicApi.Album) =>
+        ConversionUtils.convertAppleAlbum(item)
+      );
+    },
+    [fetchAppleMusicApi]
+  );
+
+  const fetchPlaylists = useCallback(async () => {
+    const response = await fetchAppleMusicApi<AppleMusicApi.PlaylistResponse>({
+      endpoint: '/playlists',
+      params: {
+        limit: 100,
+      },
+      inLibrary: true,
+    });
+
+    return response.data.map(ConversionUtils.convertApplePlaylist);
+  }, [fetchAppleMusicApi]);
+
+  const fetchPlaylist = useCallback(
+    async (playlistId: string, inLibrary = false) => {
+      const response = await fetchAppleMusicApi<AppleMusicApi.PlaylistResponse>(
+        {
+          endpoint: `/playlists/${playlistId}`,
+          params: {
+            include: 'tracks',
+          },
+          inLibrary,
+        }
+      );
+
+      return ConversionUtils.convertApplePlaylist(response.data[0]);
+    },
+    [fetchAppleMusicApi]
+  );
+
+  return {
+    fetchAlbums,
+    fetchAlbum,
+    fetchArtists,
+    fetchArtistAlbums,
+    fetchPlaylists,
+    fetchPlaylist,
+  };
+};
+
+export default useMKDataFetcher;

--- a/src/hooks/musicKit/useMKEventListener.ts
+++ b/src/hooks/musicKit/useMKEventListener.ts
@@ -17,6 +17,10 @@ const useMKEventListener = (
 
     const music = musicKit.getInstance();
 
+    if (!music) {
+      return;
+    }
+
     music.addEventListener(event, callback);
 
     return () => {

--- a/src/hooks/musicKit/useMusicKit.tsx
+++ b/src/hooks/musicKit/useMusicKit.tsx
@@ -82,9 +82,9 @@ export const MusicKitProvider = ({ children }: Props) => {
   const { setIsAppleAuthorized, setService: setStreamingService } =
     useSettings();
 
-  useEffect(() => {
+  const handleConfigure = useCallback(async () => {
     try {
-      const music = musicKit.configure({
+      const music = await musicKit.configure({
         developerToken:
           DEVELOPER_TOKEN ??
           new URLSearchParams(window.location.search).get('token') ??
@@ -106,6 +106,12 @@ export const MusicKitProvider = ({ children }: Props) => {
       setHasDevToken(false);
     }
   }, [musicKit, setIsAppleAuthorized]);
+
+  useEffect(() => {
+    if (!isConfigured) {
+      handleConfigure();
+    }
+  }, [handleConfigure, isConfigured]);
 
   useMKEventListener('userTokenDidChange', (e) => {
     if (e.userToken) {

--- a/src/hooks/utils/useDataFetcher.ts
+++ b/src/hooks/utils/useDataFetcher.ts
@@ -1,7 +1,6 @@
 import { useCallback, useEffect, useState } from 'react';
 
-import { useMusicKit, useSettings, useSpotifyDataFetcher } from 'hooks';
-import * as ConversionUtils from 'utils/conversion';
+import { useMKDataFetcher, useSettings, useSpotifyDataFetcher } from 'hooks';
 
 interface UserLibraryProps {
   inLibrary?: boolean;
@@ -53,86 +52,65 @@ type Props = CommonFetcherProps &
 
 const useDataFetcher = <TType extends object>(props: Props) => {
   const spotifyDataFetcher = useSpotifyDataFetcher();
+  const appleDataFetcher = useMKDataFetcher();
   const { service, isAppleAuthorized, isSpotifyAuthorized } = useSettings();
-  const { music } = useMusicKit();
   const [isLoading, setIsLoading] = useState(true);
   const [hasError, setHasError] = useState(false);
   const [data, setData] = useState<TType>();
   const [isMounted, setIsMounted] = useState(false);
 
-  const fetchAlbums = useCallback(
-    async (options: AlbumsFetcherProps) => {
-      let albums: IpodApi.Album[] | undefined;
+  const fetchAlbums = useCallback(async () => {
+    let albums: IpodApi.Album[] | undefined;
 
-      if (service === 'apple') {
-        const response = await (music.api as any).music(
-          `/v1/me/library/albums`
-        );
+    if (service === 'apple') {
+      albums = await appleDataFetcher.fetchAlbums();
+    } else if (service === 'spotify') {
+      albums = await spotifyDataFetcher.fetchAlbums();
+    }
 
-        albums = response.data.data.map((item: AppleMusicApi.Album) =>
-          ConversionUtils.convertAppleAlbum(item, options.artworkSize)
-        );
-      } else if (service === 'spotify') {
-        albums = await spotifyDataFetcher.fetchAlbums();
-      }
-      setData(albums as TType);
-      setIsLoading(false);
-    },
-    [music.api, service, spotifyDataFetcher]
-  );
+    setData(albums as TType);
+    setIsLoading(false);
+  }, [appleDataFetcher, service, spotifyDataFetcher]);
 
   const fetchAlbum = useCallback(
     async (options: AlbumFetcherProps) => {
       let album: IpodApi.Album | undefined;
 
       if (service === 'apple') {
-        const response = options.inLibrary
-          ? await (music.api as any).music(
-              `/v1/me/library/albums/${options.id}`
-            )
-          : // TODO: Update this to v3
-            await music.api.album(options.id);
-
-        album = ConversionUtils.convertAppleAlbum(response.data.data[0]);
+        album = await appleDataFetcher.fetchAlbum(
+          options.id,
+          options.inLibrary
+        );
       } else if (service === 'spotify') {
         album = await spotifyDataFetcher.fetchAlbum(options.userId, options.id);
       }
+
       setData(album as TType);
       setIsLoading(false);
     },
-    [music.api, service, spotifyDataFetcher]
+    [appleDataFetcher, service, spotifyDataFetcher]
   );
 
   const fetchArtists = useCallback(async () => {
     let artists: IpodApi.Artist[] | undefined;
 
     if (service === 'apple') {
-      const response = await (music.api as any).music(
-        `v1/me/library/artists?include=catalog&limit=100`
-      );
-
-      artists = response.data.data.map(ConversionUtils.convertAppleArtist);
+      artists = await appleDataFetcher.fetchArtists();
     } else if (service === 'spotify') {
       artists = await spotifyDataFetcher.fetchArtists();
     }
     setData(artists as TType);
     setIsLoading(false);
-  }, [music.api, service, spotifyDataFetcher]);
+  }, [appleDataFetcher, service, spotifyDataFetcher]);
 
   const fetchArtistAlbums = useCallback(
     async (options: ArtistFetcherProps) => {
       let albums: IpodApi.Album[] | undefined;
 
       if (service === 'apple') {
-        const response = options.inLibrary
-          ? await (music.api as any).music(
-              `v1/me/library/artists/${options.id}/albums`
-            )
-          : // ? await music.api.library.artistRelationship(options.id, 'albums')
-            await music.api.artistRelationship(options.id, 'albums');
-
-        albums = response.data.data.map((item: AppleMusicApi.Album) =>
-          ConversionUtils.convertAppleAlbum(item, options.artworkSize)
+        albums = await appleDataFetcher.fetchArtistAlbums(
+          options.id,
+          options.inLibrary
         );
       } else if (service === 'spotify') {
         albums = await spotifyDataFetcher.fetchArtist(
@@ -140,40 +118,35 @@ const useDataFetcher = <TType extends object>(props: Props) => {
           options.id
         );
       }
+
       setData(albums as TType);
       setIsLoading(false);
     },
-    [music.api, service, spotifyDataFetcher]
+    [appleDataFetcher, service, spotifyDataFetcher]
   );
 
   const fetchPlaylists = useCallback(async () => {
     let playlists: IpodApi.Playlist[] | undefined;
 
     if (service === 'apple') {
-      const response = await (music.api as any).music(
-        `v1/me/library/playlist-folders/p.playlistsroot/children`
-      );
-
-      playlists = response.data.data.map(ConversionUtils.convertApplePlaylist);
+      playlists = await appleDataFetcher.fetchPlaylists();
     } else if (service === 'spotify') {
       playlists = await spotifyDataFetcher.fetchPlaylists();
     }
+
     setData(playlists as TType);
     setIsLoading(false);
-  }, [music.api, service, spotifyDataFetcher]);
+  }, [appleDataFetcher, service, spotifyDataFetcher]);
 
   const fetchPlaylist = useCallback(
     async (options: PlaylistFetcherProps) => {
       let playlist: IpodApi.Playlist | undefined;
 
       if (service === 'apple') {
-        const response = options.inLibrary
-          ? await (music.api as any).music(
-              `v1/me/library/playlists/${options.id}?include=tracks`
-            )
-          : await music.api.playlist(options.id);
-
-        playlist = ConversionUtils.convertApplePlaylist(response.data.data[0]);
+        playlist = await appleDataFetcher.fetchPlaylist(
+          options.id,
+          options.inLibrary
+        );
       } else if (service === 'spotify') {
         playlist = await spotifyDataFetcher.fetchPlaylist(
           options.userId,
@@ -183,7 +156,7 @@ const useDataFetcher = <TType extends object>(props: Props) => {
       setData(playlist as TType);
       setIsLoading(false);
     },
-    [music.api, service, spotifyDataFetcher]
+    [appleDataFetcher, service, spotifyDataFetcher]
   );
 
   const handleMount = useCallback(async () => {
@@ -192,7 +165,7 @@ const useDataFetcher = <TType extends object>(props: Props) => {
 
     switch (props.name) {
       case 'albums':
-        await fetchAlbums(props);
+        await fetchAlbums();
         break;
       case 'album':
         await fetchAlbum(props);

--- a/src/hooks/utils/useDataFetcher.ts
+++ b/src/hooks/utils/useDataFetcher.ts
@@ -65,11 +65,11 @@ const useDataFetcher = <TType extends object>(props: Props) => {
       let albums: IpodApi.Album[] | undefined;
 
       if (service === 'apple') {
-        const response = await music.api.library.albums(null, {
-          include: 'library-albums',
-        });
+        const response = await (music.api as any).music(
+          `/v1/me/library/albums`
+        );
 
-        albums = response.map((item) =>
+        albums = response.data.data.map((item: AppleMusicApi.Album) =>
           ConversionUtils.convertAppleAlbum(item, options.artworkSize)
         );
       } else if (service === 'spotify') {
@@ -87,10 +87,13 @@ const useDataFetcher = <TType extends object>(props: Props) => {
 
       if (service === 'apple') {
         const response = options.inLibrary
-          ? await music.api.library.album(options.id)
-          : await music.api.album(options.id);
+          ? await (music.api as any).music(
+              `/v1/me/library/albums/${options.id}`
+            )
+          : // TODO: Update this to v3
+            await music.api.album(options.id);
 
-        album = ConversionUtils.convertAppleAlbum(response);
+        album = ConversionUtils.convertAppleAlbum(response.data.data[0]);
       } else if (service === 'spotify') {
         album = await spotifyDataFetcher.fetchAlbum(options.userId, options.id);
       }

--- a/src/utils/conversion.ts
+++ b/src/utils/conversion.ts
@@ -93,7 +93,7 @@ export const convertAppleAlbum = (
   id: data.id,
   name: data.attributes?.name ?? '–',
   artistName: data.attributes?.artistName,
-  url: data.attributes?.url ?? '',
+  url: data.href ?? '',
   artwork: {
     url:
       getAppleArtwork(artworkSize ?? 100, data.attributes?.artwork?.url) ?? '',

--- a/src/utils/conversion.ts
+++ b/src/utils/conversion.ts
@@ -53,7 +53,7 @@ export const convertApplePlaylist = (
 ): IpodApi.Playlist => ({
   id: data.id,
   name: data.attributes?.name ?? '–',
-  url: data.attributes?.url ?? '',
+  url: data.href ?? '',
   curatorName: data.attributes?.curatorName ?? '',
   artwork: {
     url: getAppleArtwork(100, data.attributes?.artwork?.url) ?? '',
@@ -129,7 +129,6 @@ export const convertAppleArtist = (
   id: data.id,
   name: data.attributes?.name ?? '–',
   url: data.attributes?.url ?? '',
-  artwork: undefined,
   albums: data.relationships?.albums?.data.map(convertAppleAlbum) ?? [],
 });
 

--- a/yarn.lock
+++ b/yarn.lock
@@ -5170,6 +5170,11 @@ fill-range@^7.0.1:
   dependencies:
     to-regex-range "^5.0.1"
 
+filter-obj@^1.1.0:
+  version "1.1.0"
+  resolved "https://registry.npmjs.org/filter-obj/-/filter-obj-1.1.0.tgz#9b311112bc6c6127a16e016c6c5d7f19e0805c5b"
+  integrity sha1-mzERErxsYSehbgFsbF1/GeCAXFs=
+
 finalhandler@~1.1.2:
   version "1.1.2"
   resolved "https://registry.npmjs.org/finalhandler/-/finalhandler-1.1.2.tgz#b7e7d000ffd11938d0fdb053506f6ebabe9f587d"
@@ -9146,6 +9151,16 @@ query-string@^4.1.0:
     object-assign "^4.1.0"
     strict-uri-encode "^1.0.0"
 
+query-string@^7.0.1:
+  version "7.0.1"
+  resolved "https://registry.npmjs.org/query-string/-/query-string-7.0.1.tgz#45bd149cf586aaa582dffc7ec7a8ad97dd02f75d"
+  integrity sha512-uIw3iRvHnk9to1blJCG3BTc+Ro56CBowJXKmNNAm3RulvPBzWLRqKSiiDk+IplJhsydwtuNMHi8UGQFcCLVfkA==
+  dependencies:
+    decode-uri-component "^0.2.0"
+    filter-obj "^1.1.0"
+    split-on-first "^1.0.0"
+    strict-uri-encode "^2.0.0"
+
 querystring-es3@^0.2.0:
   version "0.2.1"
   resolved "https://registry.npmjs.org/querystring-es3/-/querystring-es3-0.2.1.tgz#9ec61f79049875707d69414596fd907a4d711e73"
@@ -10241,6 +10256,11 @@ spdy@^4.0.2:
     select-hose "^2.0.0"
     spdy-transport "^3.0.0"
 
+split-on-first@^1.0.0:
+  version "1.1.0"
+  resolved "https://registry.npmjs.org/split-on-first/-/split-on-first-1.1.0.tgz#f610afeee3b12bce1d0c30425e76398b78249a5f"
+  integrity sha512-43ZssAJaMusuKWL8sKUBQXHWOpq8d6CfN/u1p4gUzfJkM05C8rxTmYrkIPTXapZpORA6LkkzcUulJ8FqA7Uudw==
+
 split-string@^3.0.1, split-string@^3.0.2:
   version "3.1.0"
   resolved "https://registry.npmjs.org/split-string/-/split-string-3.1.0.tgz#7cb09dda3a86585705c64b39a6466038682e8fe2"
@@ -10333,6 +10353,11 @@ strict-uri-encode@^1.0.0:
   version "1.1.0"
   resolved "https://registry.npmjs.org/strict-uri-encode/-/strict-uri-encode-1.1.0.tgz#279b225df1d582b1f54e65addd4352e18faa0713"
   integrity sha1-J5siXfHVgrH1TmWt3UNS4Y+qBxM=
+
+strict-uri-encode@^2.0.0:
+  version "2.0.0"
+  resolved "https://registry.npmjs.org/strict-uri-encode/-/strict-uri-encode-2.0.0.tgz#b9c7330c7042862f6b142dc274bbcc5866ce3546"
+  integrity sha1-ucczDHBChi9rFC3CdLvMWGbONUY=
 
 string-length@^4.0.1:
   version "4.0.2"


### PR DESCRIPTION
This pull upgrades MusicKit JS from v1 to v3 to take advantage of the new features and fix quite a few bugs. I also took the time during this upgrade process to move all Apple Music API calls into a new hook, `useMKDataFetcher` since we no longer have access to MusicKit convenience functions and the call to the API is more verbose than it used to be.

### Notable V3 Features
- Full MediaSession support
   <img width="442" alt="Screen Shot 2021-07-01 at 7 27 25 PM" src="https://user-images.githubusercontent.com/21055469/124211684-63de4400-daa2-11eb-8144-c86953c42c1b.png">
- Full WideVine support 
   - This allows us to bundle iPod.js into an Electron app with full Apple Music support, among other things

### Notable V3 Bug Fixes:
- 15 minute playback pause issue is resolved
- Skip previous/forward un-suppressable error message is no longer present

### Followup Items
- TypeScript support
    - MusicKit JS V3 does not have TypeScript support. According to an Apple Dev, there _may_ be a published TypeScript package later down the road, but the best path forward for now is to simply update the types locally when we need to. The MusicKit documentation is seriously lacking, so this might be a big pain point going forward.
    - For now we're casting `as any` in several places. Search for `// TODO: Update types for MusicKit V3` to see every instance where we need to update the types