### PR TITLE
Manifest: Use fullscreen display

### DIFF
--- a/public/manifest.json
+++ b/public/manifest.json
@@ -19,7 +19,8 @@
     }
   ],
   "start_url": ".",
-  "display": "standalone",
+  "display": "fullscreen",
+  "orientation": "portrait",
   "theme_color": "#000000",
-  "background_color": "#ffffff"
+  "background_color": "#000000"
 }


### PR DESCRIPTION
This pull updates the manifest to take up the entire screen and remove the status bar when added to the homescreen on Android devices.

Note that there's a sharp edge on the top of the device, but I'd like to at least start with this and hopefully make improvements down the road

<img width="462" alt="Screen Shot 2021-07-01 at 11 05 23 PM" src="https://user-images.githubusercontent.com/21055469/124228375-fb528f80-dac0-11eb-8abe-360fdd04517e.png">
