### PR TITLE
Spotify: Add support for Safari browsers

### DIFF
--- a/src/hooks/spotify/useSpotifySDK.tsx
+++ b/src/hooks/spotify/useSpotifySDK.tsx
@@ -159,7 +159,9 @@ export const SpotifySDKProvider = ({ children }: Props) => {
   }, [setIsSpotifyAuthorized, setService]);
 
   useEffectOnce(() => {
-    window.onSpotifyWebPlaybackSDKReady = handleMount;
+    if (window.Spotify) {
+      handleMount();
+    }
   });
 
   return (


### PR DESCRIPTION
This changes the way we mount the Spotify player. From my testing it appears that we now have support for playback on Safari, though I'll need to merge this to be sure. Fingers crossed 🤞 