### PR TITLE
Show popup when user is on Spotify free tier

### DIFF
--- a/src/App.tsx
+++ b/src/App.tsx
@@ -121,15 +121,15 @@ const Ipod = () => {
   return (
     <Shell deviceTheme={deviceTheme}>
       <ScreenContainer>
-        <SpotifySDKProvider>
-          <MusicKitProvider>
-            <AudioPlayerProvider>
-              <WindowProvider>
+        <WindowProvider>
+          <SpotifySDKProvider>
+            <MusicKitProvider>
+              <AudioPlayerProvider>
                 <WindowManager />
-              </WindowProvider>
-            </AudioPlayerProvider>
-          </MusicKitProvider>
-        </SpotifySDKProvider>
+              </AudioPlayerProvider>
+            </MusicKitProvider>
+          </SpotifySDKProvider>
+        </WindowProvider>
       </ScreenContainer>
       <ScrollWheel />
     </Shell>

--- a/src/components/views/index.ts
+++ b/src/components/views/index.ts
@@ -89,6 +89,11 @@ export const ViewOptions: Record<string, ViewOption> = {
     title: 'Unsupported browser',
     type: WINDOW_TYPE.POPUP,
   },
+  spotifyNonPremiumPopup: {
+    id: 'spotifyNonPremiumPopup',
+    title: 'Premium',
+    type: WINDOW_TYPE.POPUP,
+  },
 };
 
 export default ViewOptions;

--- a/src/hooks/spotify/useSpotifySDK.tsx
+++ b/src/hooks/spotify/useSpotifySDK.tsx
@@ -115,7 +115,7 @@ export const SpotifySDKProvider = ({ children }: Props) => {
     showWindow({
       type: WINDOW_TYPE.POPUP,
       id: ViewOptions.spotifyNonPremiumPopup.id,
-      title: 'Premium Account Required',
+      title: 'Unable to sign in',
       description:
         'Spotify requires a Premium account to play music on the web',
       listOptions: [

--- a/src/hooks/spotify/useSpotifySDK.tsx
+++ b/src/hooks/spotify/useSpotifySDK.tsx
@@ -104,11 +104,29 @@ interface Props {
 }
 
 export const SpotifySDKProvider = ({ children }: Props) => {
+  const { showWindow, hideWindow } = useWindowContext();
   const { setIsSpotifyAuthorized, setService } = useSettings();
   const [token, setToken] = useState<string>();
   const [deviceId, setDeviceId] = useState<string>();
   const spotifyPlayerRef = useRef<Spotify.Player | undefined>();
   const [isMounted, setIsMounted] = useState(false);
+
+  const handleUnsupportedAccountError = useCallback(() => {
+    showWindow({
+      type: WINDOW_TYPE.POPUP,
+      id: ViewOptions.spotifyNonPremiumPopup.id,
+      title: 'Premium Account Required',
+      description:
+        'Spotify requires a Premium account to play music on the web',
+      listOptions: [
+        {
+          type: 'Action',
+          label: 'Okay 😞',
+          onSelect: hideWindow,
+        },
+      ],
+    });
+  }, [hideWindow, showWindow]);
 
   /** Fetch access tokens and, if successful, then set up the playback sdk. */
   const handleMount = useCallback(async () => {
@@ -143,6 +161,11 @@ export const SpotifySDKProvider = ({ children }: Props) => {
         setIsSpotifyAuthorized(false);
       });
 
+      /** This indicates that the user is using an unsupported account tier. */
+      player.addListener('account_error', () => {
+        handleUnsupportedAccountError();
+      });
+
       player.addListener('playback_error', ({ message }) => {
         console.error(message);
       });
@@ -156,11 +179,13 @@ export const SpotifySDKProvider = ({ children }: Props) => {
         setService('spotify');
       }
     }
-  }, [setIsSpotifyAuthorized, setService]);
+  }, [handleUnsupportedAccountError, setIsSpotifyAuthorized, setService]);
 
   useEffectOnce(() => {
     if (window.Spotify) {
       handleMount();
+    } else {
+      window.onSpotifyWebPlaybackSDKReady = handleMount;
     }
   });
 


### PR DESCRIPTION
This pull adds a popup for users who sign in with a Spotify free tier account, which is unsupported by the Web Playback SDK.

![image](https://user-images.githubusercontent.com/21055469/124882638-73b7c580-df85-11eb-8894-03c6c378022f.png)

