### PR TITLE
Spotify: Remove duplicate albums from search results

### DIFF
--- a/package.json
+++ b/package.json
@@ -5,8 +5,10 @@
   "private": true,
   "homepage": "./",
   "dependencies": {
+    "@types/lodash.uniqby": "^4.7.6",
     "framer-motion": "^4.0.3",
     "he": "^1.2.0",
+    "lodash.uniqby": "^4.7.0",
     "long-press-event": "^2.4.4",
     "pluralize": "^8.0.0",
     "prettier": "^2.3.1",

--- a/src/hooks/spotify/useSpotifyDataFetcher.ts
+++ b/src/hooks/spotify/useSpotifyDataFetcher.ts
@@ -1,6 +1,7 @@
 import { useCallback } from 'react';
 
 import { useSpotifySDK } from 'hooks';
+import { uniqBy } from 'lodash';
 import * as ConversionUtils from 'utils/conversion';
 
 type FetchSpotifyApiArgs = {
@@ -92,8 +93,9 @@ const useSpotifyDataFetcher = () => {
       });
 
       if (response) {
-        return response.items.map(
-          ConversionUtils.convertSpotifyAlbumSimplified
+        return uniqBy(
+          response.items.map(ConversionUtils.convertSpotifyAlbumSimplified),
+          (item) => item.name
         );
       }
     },

--- a/yarn.lock
+++ b/yarn.lock
@@ -1924,6 +1924,18 @@
   resolved "https://registry.npmjs.org/@types/json5/-/json5-0.0.29.tgz#ee28707ae94e11d2b827bcbe5270bcea7f3e71ee"
   integrity sha1-7ihweulOEdK4J7y+UnC86n8+ce4=
 
+"@types/lodash.uniqby@^4.7.6":
+  version "4.7.6"
+  resolved "https://packages.convoy.com/artifactory/api/npm/npm/@types/lodash.uniqby/-/lodash.uniqby-4.7.6.tgz#672827a701403f07904fe37f0721ae92abfa80e8"
+  integrity sha1-ZygnpwFAPweQT+N/ByGukqv6gOg=
+  dependencies:
+    "@types/lodash" "*"
+
+"@types/lodash@*":
+  version "4.14.173"
+  resolved "https://packages.convoy.com/artifactory/api/npm/npm/@types/lodash/-/lodash-4.14.173.tgz#9d3b674c67a26cf673756f6aca7b429f237f91ed"
+  integrity sha1-nTtnTGeibPZzdW9qyntCnyN/ke0=
+
 "@types/minimatch@*":
   version "3.0.5"
   resolved "https://registry.npmjs.org/@types/minimatch/-/minimatch-3.0.5.tgz#1001cc5e6a3704b83c236027e77f2f58ea010f40"
@@ -7256,6 +7268,11 @@ lodash.uniq@^4.5.0:
   resolved "https://registry.npmjs.org/lodash.uniq/-/lodash.uniq-4.5.0.tgz#d0225373aeb652adc1bc82e4945339a842754773"
   integrity sha1-0CJTc662Uq3BvILklFM5qEJ1R3M=
 
+lodash.uniqby@^4.7.0:
+  version "4.7.0"
+  resolved "https://packages.convoy.com/artifactory/api/npm/npm/lodash.uniqby/-/lodash.uniqby-4.7.0.tgz#d99c07a669e9e6d24e1362dfe266c67616af1302"
+  integrity sha1-2ZwHpmnp5tJOE2Lf4mbGdhavEwI=
+
 "lodash@>=3.5 <5", lodash@^4.17.11, lodash@^4.17.14, lodash@^4.17.15, lodash@^4.17.19, lodash@^4.17.20, lodash@^4.17.21, lodash@^4.17.5, lodash@^4.7.0:
   version "4.17.21"
   resolved "https://registry.npmjs.org/lodash/-/lodash-4.17.21.tgz#679591c564c3bffaae8454cf0b3df370c3d6911c"
@@ -11060,7 +11077,7 @@ union-value@^1.0.0:
 
 uniq@^1.0.1:
   version "1.0.1"
-  resolved "https://registry.npmjs.org/uniq/-/uniq-1.0.1.tgz#b31c5ae8254844a3a8281541ce2b04b865a734ff"
+  resolved "https://packages.convoy.com/artifactory/api/npm/npm/uniq/-/uniq-1.0.1.tgz#b31c5ae8254844a3a8281541ce2b04b865a734ff"
   integrity sha1-sxxa6CVIRKOoKBVBzisEuGWnNP8=
 
 uniqs@^2.0.0:


### PR DESCRIPTION
For some reason Spotify's search results return more than one instance
of albums. We'll use uniqBy to ensure only one of each name is used