### PR TITLE
Add env to vercel

### DIFF
--- a/.gitignore
+++ b/.gitignore
@@ -21,3 +21,5 @@
 npm-debug.log*
 yarn-debug.log*
 yarn-error.log*
+
+.vercel

--- a/src/components/views/MusicView/index.tsx
+++ b/src/components/views/MusicView/index.tsx
@@ -1,10 +1,6 @@
 import React, { useMemo } from 'react';
 
-import {
-  getConditionalOption,
-  SelectableList,
-  SelectableListOption,
-} from 'components';
+import { SelectableList, SelectableListOption } from 'components';
 import { PREVIEW } from 'components/previews';
 import {
   AlbumsView,
@@ -15,15 +11,9 @@ import {
   SearchView,
   ViewOptions,
 } from 'components/views';
-import {
-  useMenuHideWindow,
-  useMusicKit,
-  useScrollHandler,
-  useSettings,
-} from 'hooks';
+import { useMenuHideWindow, useMusicKit, useScrollHandler } from 'hooks';
 
 const MusicView = () => {
-  const { service } = useSettings();
   const { music } = useMusicKit();
   useMenuHideWindow(ViewOptions.music.id);
 
@@ -77,7 +67,7 @@ const MusicView = () => {
     }
 
     return arr;
-  }, [music.isAuthorized, music.player?.nowPlayingItem?.isPlayable, service]);
+  }, [music.isAuthorized, music.player?.nowPlayingItem?.isPlayable]);
 
   const [scrollIndex] = useScrollHandler(ViewOptions.music.id, options);
 

--- a/src/hooks/musicKit/useMusicKit.tsx
+++ b/src/hooks/musicKit/useMusicKit.tsx
@@ -16,7 +16,8 @@ import { useEventListener, useMKEventListener, useSettings } from 'hooks';
  * @see https://developer.apple.com/documentation/applemusicapi/getting_keys_and_creating_tokens
  */
 // eslint-disable-next-line @typescript-eslint/no-unused-vars
-const DEVELOPER_TOKEN: string | undefined = undefined;
+const DEVELOPER_TOKEN: string | undefined =
+  process.env.REACT_APP_APPLE_DEV_TOKEN;
 
 export interface MusicKitState {
   musicKit: typeof MusicKit;


### PR DESCRIPTION
This pull sets up Vercel to properly deploy previews that include developer tokens for Apple Music. Any pull request can now be deployed to a preview url and viewed without any manual token manipulation.