### PR TITLE
Remove requirement for MusicKit Token

### DIFF
--- a/src/components/AuthPrompt/index.tsx
+++ b/src/components/AuthPrompt/index.tsx
@@ -1,6 +1,6 @@
 import { useState } from 'react';
 
-import { useInterval } from 'hooks';
+import { useInterval, useMusicKit } from 'hooks';
 import styled, { css } from 'styled-components';
 import { Unit } from 'utils/constants';
 
@@ -56,10 +56,20 @@ interface Props {
 }
 
 const AuthPrompt = ({ message }: Props) => {
-  const [icon, setIcon] = useState<'apple' | 'spotify'>('apple');
+  const { isConfigured: isMkConfigured } = useMusicKit();
+  const [icon, setIcon] = useState<'apple' | 'spotify'>(
+    isMkConfigured ? 'apple' : 'spotify'
+  );
 
   useInterval(
-    () => setIcon((prevState) => (prevState === 'apple' ? 'spotify' : 'apple')),
+    () =>
+      setIcon((prevState) => {
+        if (prevState === 'apple' || !isMkConfigured) {
+          return 'spotify';
+        }
+
+        return 'apple';
+      }),
     4000
   );
 
@@ -70,11 +80,13 @@ const AuthPrompt = ({ message }: Props) => {
         alt="app_icon"
         src="apple_music_icon.svg"
       />
-      <StyledImg
-        isHidden={icon === 'apple'}
-        alt="app_icon"
-        src="spotify_icon.svg"
-      />
+      {isMkConfigured && (
+        <StyledImg
+          isHidden={icon === 'apple'}
+          alt="app_icon"
+          src="spotify_icon.svg"
+        />
+      )}
       <Title>{strings.title[icon]}</Title>
       <Text>{message ?? strings.defaultMessage}</Text>
     </RootContainer>

--- a/src/components/WindowManager/index.tsx
+++ b/src/components/WindowManager/index.tsx
@@ -1,6 +1,5 @@
-import { ErrorScreen } from 'components';
 import { WINDOW_TYPE } from 'components/views';
-import { useEventListener, useMusicKit, useWindowContext } from 'hooks';
+import { useEventListener, useWindowContext } from 'hooks';
 import styled from 'styled-components';
 import { IpodEvent } from 'utils/events';
 
@@ -22,7 +21,6 @@ const Mask = styled.div`
 `;
 
 const WindowManager = () => {
-  const { isConfigured, hasDevToken: hasAppleDevToken } = useMusicKit();
   const { windowStack, resetWindows } = useWindowContext();
   const splitViewWindows = windowStack.filter(
     (window) => window.type === WINDOW_TYPE.SPLIT
@@ -43,28 +41,20 @@ const WindowManager = () => {
     (window) => window.type === WINDOW_TYPE.KEYBOARD
   );
 
-  const isReady = isConfigured && hasAppleDevToken;
-
   useEventListener<IpodEvent>('menulongpress', resetWindows);
 
   return (
     <div>
-      {isReady ? (
-        <>
-          <CoverFlowWindowManager window={coverFlowWindow} />
-          <SplitScreenWindowManager
-            windowStack={splitViewWindows}
-            menuHidden={fullViewWindows.length > 0}
-            allHidden={!!coverFlowWindow}
-          />
-          <FullScreenWindowManager windowStack={fullViewWindows} />
-          <ActionSheetWindowManager windowStack={actionSheetWindows} />
-          <PopupWindowManager windowStack={popupWindows} />
-          <KeyboardWindowManager windowStack={keyboardWindows} />
-        </>
-      ) : (
-        <ErrorScreen message={'Missing developer token'} />
-      )}
+      <CoverFlowWindowManager window={coverFlowWindow} />
+      <SplitScreenWindowManager
+        windowStack={splitViewWindows}
+        menuHidden={fullViewWindows.length > 0}
+        allHidden={!!coverFlowWindow}
+      />
+      <FullScreenWindowManager windowStack={fullViewWindows} />
+      <ActionSheetWindowManager windowStack={actionSheetWindows} />
+      <PopupWindowManager windowStack={popupWindows} />
+      <KeyboardWindowManager windowStack={keyboardWindows} />
       <Mask />
     </div>
   );

--- a/src/components/previews/MusicPreview.tsx
+++ b/src/components/previews/MusicPreview.tsx
@@ -17,6 +17,7 @@ const Container = styled(motion.div)`
 
 const MusicPreview = () => {
   const { isSpotifyAuthorized, isAppleAuthorized } = useSettings();
+
   const {
     data: albums,
     isLoading,

--- a/src/components/views/HomeView/index.tsx
+++ b/src/components/views/HomeView/index.tsx
@@ -32,7 +32,8 @@ const strings = {
 
 const HomeView = () => {
   const { isAuthorized } = useSettings();
-  const { signIn: signInWithApple } = useMusicKit();
+  const { signIn: signInWithApple, isConfigured: isMkConfigured } =
+    useMusicKit();
   const { nowPlayingItem } = useAudioPlayer();
   const { signIn: signInWithSpotify } = useSpotifySDK();
   const { showWindow, windowStack } = useWindowContext();
@@ -67,16 +68,17 @@ const HomeView = () => {
         component: () => <SettingsView />,
         preview: PREVIEW.SETTINGS,
       },
+      // Show the sign in buttons if the user is not logged in.
       ...getConditionalOption(!isAuthorized, {
         type: 'ActionSheet',
         id: ViewOptions.signinPopup.id,
         label: 'Sign in',
         listOptions: [
-          {
+          ...getConditionalOption(isMkConfigured, {
             type: 'Action',
             label: 'Apple Music',
             onSelect: signInWithApple,
-          },
+          }),
           {
             type: 'Action',
             label: 'Spotify',
@@ -93,7 +95,13 @@ const HomeView = () => {
         preview: PREVIEW.NOW_PLAYING,
       }),
     ],
-    [isAuthorized, nowPlayingItem, signInWithApple, signInWithSpotify]
+    [
+      isAuthorized,
+      isMkConfigured,
+      nowPlayingItem,
+      signInWithApple,
+      signInWithSpotify,
+    ]
   );
 
   const [scrollIndex] = useScrollHandler(ViewOptions.home.id, options);

--- a/src/components/views/SettingsView/index.tsx
+++ b/src/components/views/SettingsView/index.tsx
@@ -25,7 +25,11 @@ const SettingsView = () => {
     deviceTheme,
     setDeviceTheme,
   } = useSettings();
-  const { signIn: signInWithApple, signOut: signOutApple } = useMusicKit();
+  const {
+    signIn: signInWithApple,
+    signOut: signOutApple,
+    isConfigured: isMkConfigured,
+  } = useMusicKit();
   const { signOut: signOutSpotify, signIn: signInWithSpotify } =
     useSpotifySDK();
 
@@ -91,11 +95,11 @@ const SettingsView = () => {
         id: ViewOptions.signinPopup.id,
         label: 'Sign in',
         listOptions: [
-          {
+          ...getConditionalOption(isMkConfigured, {
             type: 'Action',
             label: 'Apple Music',
-            onSelect: signInWithApple,
-          },
+            onSelect: signOutApple,
+          }),
           {
             type: 'Action',
             label: 'Spotify',
@@ -125,16 +129,17 @@ const SettingsView = () => {
       }),
     ],
     [
-      deviceTheme,
-      setDeviceTheme,
-      isAppleAuthorized,
       isAuthorized,
-      isSpotifyAuthorized,
       service,
       signInWithApple,
       signInWithSpotify,
+      deviceTheme,
+      isMkConfigured,
       signOutApple,
+      isAppleAuthorized,
+      isSpotifyAuthorized,
       signOutSpotify,
+      setDeviceTheme,
     ]
   );
 

--- a/src/hooks/musicKit/useMKEventListener.ts
+++ b/src/hooks/musicKit/useMKEventListener.ts
@@ -9,9 +9,9 @@ const useMKEventListener = (
   callback: (...args: any) => void
 ) => {
   useEffect(() => {
-    const musicKit = window.MusicKit;
+    const musicKit = window.MusicKit || undefined;
 
-    if (musicKit.errors.length) {
+    if (!musicKit || musicKit.errors.length) {
       return;
     }
 

--- a/src/hooks/musicKit/useMusicKit.tsx
+++ b/src/hooks/musicKit/useMusicKit.tsx
@@ -8,7 +8,6 @@ import React, {
   useState,
 } from 'react';
 
-import { ErrorScreen } from 'components';
 import { useEventListener, useMKEventListener, useSettings } from 'hooks';
 
 /**
@@ -43,7 +42,7 @@ export const useMusicKit = (): MusicKitHook => {
       return {} as MusicKit.MusicKitInstance;
     }
 
-    return window.MusicKit.getInstance();
+    return window.MusicKit?.getInstance();
   }, [hasDevToken, isConfigured]);
 
   const signIn = useCallback(async () => {
@@ -130,11 +129,7 @@ export const MusicKitProvider = ({ children }: Props) => {
 
   return (
     <MusicKitContext.Provider value={{ musicKit, isConfigured, hasDevToken }}>
-      {isConfigured ? (
-        children
-      ) : (
-        <ErrorScreen message={'Missing Apple developer token'} />
-      )}
+      {children}
     </MusicKitContext.Provider>
   );
 };


### PR DESCRIPTION
This pull adds a few extra safeguards to allow for the removal of the MusicKit JS token requirement.

If a token is not provided, the app will simply disable Apple Music functionality and still be fully usable with Spotify. This should make it much easier for developers to add features to this repo without having to worry about finding a dev token that works