### PR TITLE
Introduce pagination for Playlists, Artists, and Albums

### DIFF
--- a/src/components/SelectableList/index.tsx
+++ b/src/components/SelectableList/index.tsx
@@ -1,10 +1,10 @@
-import { useEffect, useRef, useState } from 'react';
+import { useEffect, useMemo, useRef, useState } from 'react';
 
-import { LoadingScreen } from 'components';
+import { LoadingIndicator, LoadingScreen } from 'components';
 import ErrorScreen from 'components/ErrorScreen';
 import { PREVIEW } from 'components/previews';
 import { WINDOW_TYPE } from 'components/views';
-import { AnimatePresence } from 'framer-motion';
+import { AnimatePresence, motion } from 'framer-motion';
 import { useTimeout } from 'hooks';
 import styled from 'styled-components';
 
@@ -25,7 +25,7 @@ export type SelectableListOptionType =
 
 type SharedOptionProps = {
   type?: SelectableListOptionType;
-  label: string;
+  label: React.ReactNode;
   isSelected?: boolean;
   sublabel?: string;
   preview?: PREVIEW;
@@ -98,10 +98,18 @@ const Container = styled.div`
   -webkit-overflow-scrolling: touch;
 `;
 
+const LoadingContainer = styled(motion.div)`
+  display: flex;
+  justify-content: center;
+  align-items: center;
+  height: 2rem;
+`;
+
 interface Props {
   options: SelectableListOption[];
   activeIndex: number;
   loading?: boolean;
+  loadingNextItems?: boolean;
   emptyMessage?: string;
 }
 
@@ -109,6 +117,7 @@ const SelectableList = ({
   options,
   activeIndex,
   loading,
+  loadingNextItems,
   emptyMessage = 'Nothing to see here',
 }: Props) => {
   const containerRef = useRef<HTMLDivElement>(null);
@@ -116,18 +125,43 @@ const SelectableList = ({
 
   useTimeout(() => setIsMounted(true), 350);
 
+  const fullOptions = useMemo(
+    () => [
+      ...options,
+      // Show a loading indicator when loading more items.
+      ...getConditionalOption(loadingNextItems, {
+        type: 'Action',
+        label: (
+          <LoadingContainer>
+            <LoadingIndicator size={16} />
+          </LoadingContainer>
+        ),
+        onSelect: () => {},
+      }),
+    ],
+    [options, loadingNextItems]
+  );
+
   /** Always make sure the selected item is within the screen's view. */
   useEffect(() => {
     // Delay "isMounted" so that the enter animation doesn't get interrupted.
     // I was stuck on this for like 12 hours and was wondering why
     // the animation wasn't finishing...
-    if (isMounted && containerRef.current && options.length) {
+    if (isMounted && containerRef.current && fullOptions.length) {
       const { children } = containerRef.current;
-      children[activeIndex]?.scrollIntoView({
-        block: 'nearest',
-      });
+
+      // Make sure the pagination loading indicator is in view.
+      if (loadingNextItems) {
+        children[activeIndex + 1]?.scrollIntoView({
+          block: 'nearest',
+        });
+      } else {
+        children[activeIndex]?.scrollIntoView({
+          block: 'nearest',
+        });
+      }
     }
-  }, [activeIndex, isMounted, options.length]);
+  }, [activeIndex, isMounted, fullOptions.length, loadingNextItems]);
 
   return (
     <AnimatePresence>
@@ -135,7 +169,7 @@ const SelectableList = ({
         <LoadingScreen backgroundColor="white" />
       ) : options.length > 0 ? (
         <Container ref={containerRef}>
-          {options.map((option, index) => (
+          {fullOptions.map((option, index) => (
             <SelectableListItem
               key={`option-${option.label}-${index}`}
               option={option}

--- a/src/components/previews/MusicPreview.tsx
+++ b/src/components/previews/MusicPreview.tsx
@@ -28,7 +28,9 @@ const MusicPreview = () => {
 
   const artworkUrls = useMemo(() => {
     if (albums && !error) {
-      return albums.map((album) => album.artwork?.url ?? '');
+      return albums.pages.flatMap(
+        (page) => page?.data.map((album) => album.artwork?.url ?? '') ?? []
+      );
     }
 
     return [];

--- a/src/components/views/AlbumsView/index.tsx
+++ b/src/components/views/AlbumsView/index.tsx
@@ -32,10 +32,7 @@ const AlbumsView = ({ albums, inLibrary = true }: Props) => {
 
   const options: SelectableListOption[] = useMemo(() => {
     const data =
-      albums ??
-      fetchedAlbums?.pages.flatMap(
-        (page) => page?.data.map((album) => album) ?? []
-      );
+      albums ?? fetchedAlbums?.pages.flatMap((page) => page?.data ?? []);
 
     return (
       data?.map((album) => ({

--- a/src/components/views/ArtistsView/index.tsx
+++ b/src/components/views/ArtistsView/index.tsx
@@ -24,13 +24,21 @@ const ArtistsView = ({
 }: Props) => {
   useMenuHideWindow(ViewOptions.artists.id);
   const { isAuthorized } = useSettings();
-  const { data: fetchedArtists, isLoading: isQueryLoading } = useFetchArtists({
+  const {
+    data: fetchedArtists,
+    fetchNextPage,
+    isFetchingNextPage,
+    isLoading: isQueryLoading,
+  } = useFetchArtists({
     lazy: !!artists,
   });
 
-  const options: SelectableListOption[] = useMemo(
-    () =>
-      (artists ?? fetchedArtists)?.map((artist) => ({
+  const options: SelectableListOption[] = useMemo(() => {
+    const data =
+      artists ?? fetchedArtists?.pages.flatMap((page) => page?.data ?? []);
+
+    return (
+      data?.map((artist) => ({
         type: 'View',
         headerTitle: artist.name,
         label: artist.name,
@@ -39,23 +47,29 @@ const ArtistsView = ({
           ? Utils.getArtwork(50, artist.artwork?.url) ?? 'artists_icon.svg'
           : '',
         component: () => <ArtistView id={artist.id} inLibrary={inLibrary} />,
-      })) ?? [],
-    [artists, fetchedArtists, inLibrary, showImages]
-  );
+      })) ?? []
+    );
+  }, [artists, fetchedArtists, inLibrary, showImages]);
 
   // If accessing ArtistsView from the SearchView, and there is no data cached,
   // 'isQueryLoading' will be true. To prevent an infinite loading screen in these
   // cases, we'll check if we have any 'options'
   const isLoading = !options.length && isQueryLoading;
 
-  const [scrollIndex] = useScrollHandler(ViewOptions.artists.id, options);
+  const [scrollIndex] = useScrollHandler(
+    ViewOptions.artists.id,
+    options,
+    undefined,
+    fetchNextPage
+  );
 
   return isAuthorized ? (
     <SelectableList
-      loading={isLoading}
-      options={options}
       activeIndex={scrollIndex}
       emptyMessage="No saved artists"
+      loading={isLoading}
+      loadingNextItems={isFetchingNextPage}
+      options={options}
     />
   ) : (
     <AuthPrompt message="Sign in to view your artists" />

--- a/src/components/views/CoverFlowView/index.tsx
+++ b/src/components/views/CoverFlowView/index.tsx
@@ -1,4 +1,4 @@
-import React, { useCallback } from 'react';
+import { useMemo, useCallback } from 'react';
 
 import { AuthPrompt, LoadingScreen } from 'components';
 import {
@@ -23,6 +23,13 @@ const CoverFlowView = () => {
     artworkSize: 350,
   });
 
+  const flattenedAlbums = useMemo(
+    () =>
+      albums?.pages.flatMap((page) => page?.data.map((album) => album) ?? []) ??
+      [],
+    [albums]
+  );
+
   const handleMenuClick = useCallback(() => {
     if (!isAuthorized || isLoading) {
       hideWindow();
@@ -38,7 +45,7 @@ const CoverFlowView = () => {
       ) : !isAuthorized ? (
         <AuthPrompt message="Sign in to view Cover Flow" />
       ) : (
-        <CoverFlow albums={albums ?? []} />
+        <CoverFlow albums={flattenedAlbums} />
       )}
     </Container>
   );

--- a/src/components/views/CoverFlowView/index.tsx
+++ b/src/components/views/CoverFlowView/index.tsx
@@ -24,9 +24,7 @@ const CoverFlowView = () => {
   });
 
   const flattenedAlbums = useMemo(
-    () =>
-      albums?.pages.flatMap((page) => page?.data.map((album) => album) ?? []) ??
-      [],
+    () => albums?.pages.flatMap((page) => page?.data ?? []) ?? [],
     [albums]
   );
 

--- a/src/hooks/musicKit/useMKDataFetcher.ts
+++ b/src/hooks/musicKit/useMKDataFetcher.ts
@@ -47,21 +47,31 @@ const useMKDataFetcher = () => {
     [isConfigured, music]
   );
 
-  const fetchAlbums = useCallback(async () => {
-    const response = await fetchAppleMusicApi<AppleMusicApi.AlbumResponse>({
-      endpoint: `/albums`,
-      inLibrary: true,
-      params: {
-        limit: 100,
-      },
-    });
+  const fetchAlbums = useCallback(
+    async ({ pageParam, limit }: { pageParam: number; limit: number }) => {
+      const offset = pageParam * limit;
 
-    if (response) {
-      return response.data.map((item: AppleMusicApi.Album) =>
-        ConversionUtils.convertAppleAlbum(item, 300)
-      );
-    }
-  }, [fetchAppleMusicApi]);
+      const response = await fetchAppleMusicApi<AppleMusicApi.AlbumResponse>({
+        endpoint: `/albums`,
+        inLibrary: true,
+        params: {
+          limit,
+          offset,
+        },
+      });
+      const totalResults = response?.meta.total ?? 0;
+
+      return {
+        data:
+          response?.data.map((item: AppleMusicApi.Album) =>
+            ConversionUtils.convertAppleAlbum(item, 300)
+          ) ?? [],
+        nextPageParam:
+          offset >= totalResults - limit ? undefined : pageParam + 1,
+      };
+    },
+    [fetchAppleMusicApi]
+  );
 
   const fetchAlbum = useCallback(
     async (id: string, inLibrary = false) => {

--- a/src/hooks/navigation/useScrollHandler.tsx
+++ b/src/hooks/navigation/useScrollHandler.tsx
@@ -40,7 +40,11 @@ const useScrollHandler = (
   /** A list of all scrollable items. Used to cap the scrolling to the last element. */
   options: SelectableListOption[] = [],
   selectedOption?: SelectableListOption,
-  onScrolledToEnd?: (...args: any) => any
+  /**
+   * This function is called when the user has scrolled close to the end of the list of options.
+   * Useful for fetching the next page of data before the user reaches the end of the list.
+   */
+  onNearEndOfList?: (...args: any) => any
 ): [number] => {
   const { triggerHaptics } = useHapticFeedback();
   const { showWindow, windowStack, setPreview } = useWindowContext();
@@ -79,8 +83,9 @@ const useScrollHandler = (
         triggerHaptics(10);
         handleCheckForPreview(prevIndex + 1);
 
-        if (prevIndex === options.length - 2) {
-          onScrolledToEnd?.(options.length);
+        // Trigger near-end-of-list callback when we're halfway through the current list.
+        if (prevIndex === Math.round(options.length / 2)) {
+          onNearEndOfList?.(options.length);
         }
 
         return prevIndex + 1;
@@ -91,7 +96,7 @@ const useScrollHandler = (
   }, [
     handleCheckForPreview,
     isActive,
-    onScrolledToEnd,
+    onNearEndOfList,
     options.length,
     triggerHaptics,
   ]);

--- a/src/hooks/navigation/useScrollHandler.tsx
+++ b/src/hooks/navigation/useScrollHandler.tsx
@@ -39,7 +39,8 @@ const useScrollHandler = (
   id: string,
   /** A list of all scrollable items. Used to cap the scrolling to the last element. */
   options: SelectableListOption[] = [],
-  selectedOption?: SelectableListOption
+  selectedOption?: SelectableListOption,
+  onScrolledToEnd?: (...args: any) => any
 ): [number] => {
   const { triggerHaptics } = useHapticFeedback();
   const { showWindow, windowStack, setPreview } = useWindowContext();
@@ -73,20 +74,39 @@ const useScrollHandler = (
   );
 
   const handleForwardScroll = useCallback(() => {
-    if (index < options.length - 1 && isActive) {
-      triggerHaptics(10);
-      setIndex(index + 1);
-      handleCheckForPreview(index + 1);
-    }
-  }, [handleCheckForPreview, index, isActive, options.length, triggerHaptics]);
+    setIndex((prevIndex) => {
+      if (prevIndex < options.length - 1 && isActive) {
+        triggerHaptics(10);
+        handleCheckForPreview(prevIndex + 1);
+
+        if (prevIndex === options.length - 2) {
+          onScrolledToEnd?.(options.length);
+        }
+
+        return prevIndex + 1;
+      }
+
+      return prevIndex;
+    });
+  }, [
+    handleCheckForPreview,
+    isActive,
+    onScrolledToEnd,
+    options.length,
+    triggerHaptics,
+  ]);
 
   const handleBackwardScroll = useCallback(() => {
-    if (index > 0 && isActive) {
-      triggerHaptics(10);
-      setIndex(index - 1);
-      handleCheckForPreview(index - 1);
-    }
-  }, [handleCheckForPreview, index, isActive, triggerHaptics]);
+    setIndex((prevIndex) => {
+      if (prevIndex > 0 && isActive) {
+        triggerHaptics(10);
+        handleCheckForPreview(prevIndex + 1);
+        return prevIndex - 1;
+      }
+
+      return prevIndex;
+    });
+  }, [handleCheckForPreview, isActive, triggerHaptics]);
 
   const handleShowView = useCallback(
     (

--- a/src/hooks/utils/useDataFetcher.ts
+++ b/src/hooks/utils/useDataFetcher.ts
@@ -103,7 +103,7 @@ export const useFetchArtists = (options: CommonFetcherProps) => {
 
   return useInfiniteQuery(
     ['artists'],
-    async ({ pageParam }) => {
+    async ({ pageParam = 0 }) => {
       const params = {
         pageParam,
         limit: 20,

--- a/src/hooks/utils/useDataFetcher.ts
+++ b/src/hooks/utils/useDataFetcher.ts
@@ -63,7 +63,7 @@ export const useFetchAlbum = (
       if (service === 'apple') {
         return appleDataFetcher.fetchAlbum(options.id, options.inLibrary);
       } else if (service === 'spotify') {
-        return spotifyDataFetcher.fetchAlbum(options.userId, options.id);
+        return spotifyDataFetcher.fetchAlbum({ id: options.id });
       }
     },
     { enabled: enabled && !options.lazy }
@@ -79,15 +79,15 @@ export const useFetchAlbums = (
   return useInfiniteQuery(
     ['albums'],
     async ({ pageParam = 0 }) => {
-      const options = {
+      const params = {
         pageParam,
         limit: 50,
       };
 
       if (service === 'apple') {
-        return appleDataFetcher.fetchAlbums(options);
+        return appleDataFetcher.fetchAlbums(params);
       } else if (service === 'spotify') {
-        return spotifyDataFetcher.fetchAlbums(options);
+        return spotifyDataFetcher.fetchAlbums(params);
       }
     },
     {
@@ -101,16 +101,27 @@ export const useFetchArtists = (options: CommonFetcherProps) => {
   const { spotifyDataFetcher, appleDataFetcher, service, enabled } =
     useDataFetchers();
 
-  return useQuery(
+  return useInfiniteQuery(
     ['artists'],
-    async () => {
+    async ({ pageParam }) => {
+      const params = {
+        pageParam,
+        limit: 20,
+        after: pageParam,
+      };
+
       if (service === 'apple') {
-        return appleDataFetcher.fetchArtists();
+        return appleDataFetcher.fetchArtists(params);
       } else if (service === 'spotify') {
-        return spotifyDataFetcher.fetchArtists();
+        return spotifyDataFetcher.fetchArtists(params);
       }
     },
-    { enabled: enabled && !options.lazy }
+    {
+      enabled: enabled && !options.lazy,
+      // TODO: Figure out a better way to deal with `after` param
+      getNextPageParam: (lastPage) =>
+        service === 'spotify' ? lastPage?.after : lastPage?.nextPageParam,
+    }
   );
 };
 
@@ -140,16 +151,24 @@ export const useFetchPlaylists = (options: CommonFetcherProps) => {
   const { spotifyDataFetcher, appleDataFetcher, service, enabled } =
     useDataFetchers();
 
-  return useQuery(
+  return useInfiniteQuery(
     ['playlists'],
-    async () => {
+    async ({ pageParam = 0 }) => {
+      const params = {
+        limit: 20,
+        pageParam,
+      };
+
       if (service === 'apple') {
-        return appleDataFetcher.fetchPlaylists();
+        return appleDataFetcher.fetchPlaylists(params);
       } else if (service === 'spotify') {
-        return spotifyDataFetcher.fetchPlaylists();
+        return spotifyDataFetcher.fetchPlaylists(params);
       }
     },
-    { enabled: enabled && !options.lazy }
+    {
+      enabled: enabled && !options.lazy,
+      getNextPageParam: (lastPage) => lastPage?.nextPageParam,
+    }
   );
 };
 
@@ -165,7 +184,7 @@ export const useFetchPlaylist = (
       if (service === 'apple') {
         return appleDataFetcher.fetchPlaylist(options.id, options.inLibrary);
       } else if (service === 'spotify') {
-        return spotifyDataFetcher.fetchPlaylist(options.userId, options.id);
+        return spotifyDataFetcher.fetchPlaylist(options.id);
       }
     },
     { enabled: enabled && !options.lazy }

--- a/src/hooks/utils/useDataFetcher.ts
+++ b/src/hooks/utils/useDataFetcher.ts
@@ -1,4 +1,4 @@
-import { useQuery } from '@tanstack/react-query';
+import { useInfiniteQuery, useQuery } from '@tanstack/react-query';
 
 import {
   useMKDataFetcher,
@@ -76,16 +76,24 @@ export const useFetchAlbums = (
   const { spotifyDataFetcher, appleDataFetcher, service, enabled } =
     useDataFetchers();
 
-  return useQuery(
+  return useInfiniteQuery(
     ['albums'],
-    async () => {
+    async ({ pageParam = 0 }) => {
+      const options = {
+        pageParam,
+        limit: 50,
+      };
+
       if (service === 'apple') {
-        return appleDataFetcher.fetchAlbums();
+        return appleDataFetcher.fetchAlbums(options);
       } else if (service === 'spotify') {
-        return spotifyDataFetcher.fetchAlbums();
+        return spotifyDataFetcher.fetchAlbums(options);
       }
     },
-    { enabled: enabled && !options.lazy }
+    {
+      enabled: enabled && !options.lazy,
+      getNextPageParam: (lastPage) => lastPage?.nextPageParam,
+    }
   );
 };
 

--- a/src/types/AppleMusic.API.d.ts
+++ b/src/types/AppleMusic.API.d.ts
@@ -6,6 +6,10 @@
 
 declare namespace AppleMusicApi {
   // https://developer.apple.com/documentation/applemusicapi/songresponse
+
+  interface ResponseMetadata {
+    total: number;
+  }
   interface SongResponse {
     data: Song[];
   }
@@ -13,6 +17,7 @@ declare namespace AppleMusicApi {
   // https://developer.apple.com/documentation/applemusicapi/albumresponse
   interface AlbumResponse {
     data: Album[];
+    meta: ResponseMetadata;
   }
 
   // https://developer.apple.com/documentation/applemusicapi/playlistresponse

--- a/src/types/AppleMusic.API.d.ts
+++ b/src/types/AppleMusic.API.d.ts
@@ -23,11 +23,13 @@ declare namespace AppleMusicApi {
   // https://developer.apple.com/documentation/applemusicapi/playlistresponse
   interface PlaylistResponse {
     data: Playlist[];
+    meta: ResponseMetadata;
   }
 
   // https://developer.apple.com/documentation/applemusicapi/artistresponse
   interface ArtistResponse {
     data: Artist[];
+    meta: ResponseMetadata;
   }
 
   // https://developer.apple.com/documentation/applemusicapi/relationship

--- a/src/types/Ipod.API.d.ts
+++ b/src/types/Ipod.API.d.ts
@@ -62,4 +62,16 @@ declare namespace IpodApi {
     albums: Album[];
     playlists: Playlist[];
   }
+
+  interface PaginationParams {
+    pageParam: number;
+    limit: number;
+    after?: string;
+  }
+
+  interface PaginatedResponse<TType> {
+    data: TType;
+    nextPageParam?: number;
+    after?: string;
+  }
 }


### PR DESCRIPTION
This pull sets up pagination using the `useInfiniteQuery` hook. When the user scrolls halfway through a list of playlists, artists, or albums, a network request will be triggered to fetch the next page of items from the server and add them to the bottom of the list. As the user continues to scroll, more and more items will be added until reaching the end.

Massive props to @JohnDaly for introducing `useQuery` to the project. This wouldn't have been possible without it!

https://user-images.githubusercontent.com/21055469/180679553-605e5a41-97b8-46d7-9ebc-ce6f568dc0fb.mp4

Closes #34 

