### PR TITLE
js(useAudioPlayer): Add `activateElement` function to playSpotify

### DIFF
--- a/package.json
+++ b/package.json
@@ -54,7 +54,7 @@
     "@types/pluralize": "^0.0.29",
     "@types/react": "17.0.1",
     "@types/react-dom": "^16.9.10",
-    "@types/spotify-api": "^0.0.8",
+    "@types/spotify-api": "^0.0.19",
     "@types/spotify-web-playback-sdk": "^0.1.8",
     "@types/styled-components": "^5.1.9",
     "typescript": "4.1.2"

--- a/src/hooks/audio/useAudioPlayer.tsx
+++ b/src/hooks/audio/useAudioPlayer.tsx
@@ -100,6 +100,10 @@ export const AudioPlayerProvider = ({ children }: Props) => {
         throw new Error('Unable to play: Not authorized');
       }
 
+      // Safari on iOS requires a user interaction to activate the player.
+      // This function exists in the Spotify SDK, but is not present in the types.
+      await (spotifyPlayer as unknown as any).activateElement();
+
       // Spotify only accepts a list of song URIs, so we'll look through each media type provided for songs.
       const uris = [
         ...(queueOptions.album?.songs?.map((song) => song.url) ?? []),
@@ -133,7 +137,7 @@ export const AudioPlayerProvider = ({ children }: Props) => {
         isLoading: false,
       }));
     },
-    [accessToken, deviceId, isSpotifyAuthorized]
+    [accessToken, deviceId, isSpotifyAuthorized, spotifyPlayer]
   );
 
   const play = useCallback(

--- a/src/utils/conversion.ts
+++ b/src/utils/conversion.ts
@@ -83,7 +83,9 @@ export const convertSpotifyPlaylistFull = (
   url: data.uri,
   artwork: { url: data.images[0]?.url ?? '' },
   description: data.description ?? '',
-  songs: data.tracks.items.map((item) => convertSpotifySongFull(item.track)),
+  songs: data.tracks.items
+    .filter((item) => !!item)
+    .map((item) => convertSpotifySongFull(item.track!)),
 });
 
 export const convertAppleAlbum = (

--- a/yarn.lock
+++ b/yarn.lock
@@ -2040,10 +2040,10 @@
   resolved "https://registry.npmjs.org/@types/source-list-map/-/source-list-map-0.1.2.tgz#0078836063ffaf17412349bba364087e0ac02ec9"
   integrity sha512-K5K+yml8LTo9bWJI/rECfIPrGgxdpeNbj+d53lwN4QjW1MCwlkhUms+gtdzigTeUyBr09+u8BwOIY3MXvHdcsA==
 
-"@types/spotify-api@^0.0.8":
-  version "0.0.8"
-  resolved "https://registry.npmjs.org/@types/spotify-api/-/spotify-api-0.0.8.tgz#e71c6c963163f92dd20604102cab6517e620944b"
-  integrity sha512-ChhUuVkIcf1lb2sD2R5JmNyCIOtl0AzqQ6Id4bZDNRo4AuDo2O9mUnh6Dmn3EB5JLGfWi0qdxmP/6Zvu7L/Rpw==
+"@types/spotify-api@^0.0.19":
+  version "0.0.19"
+  resolved "https://registry.yarnpkg.com/@types/spotify-api/-/spotify-api-0.0.19.tgz#8788819f199b90ad2784b97390a2d353c7463cb1"
+  integrity sha512-tdtxjhZs7w/dN7kpeezRe492kXzWXvilW/1ibNMoM2ymcRwKCrK5exEeBNCZhwZMtG+S2eZMaAaBsnTnqun1PQ==
 
 "@types/spotify-web-playback-sdk@^0.1.8":
   version "0.1.11"


### PR DESCRIPTION
This is a small fix for Spotify playback on iOS. When playing a song for the first time, it wouldn't start without pressing the play button again once you're on the now playing screen.

I've added a function called `activateElement` described in the [Spotify player docs](https://developer.spotify.com/documentation/web-playback-sdk/reference/#api-spotify-player-activateelement). This will be invoked when the user plays any song and will allow songs to be played without needing users to press play again