### PR TITLE
Sort ArtistsView alphabetically

### DIFF
--- a/src/components/views/ArtistsView/index.tsx
+++ b/src/components/views/ArtistsView/index.tsx
@@ -37,6 +37,8 @@ const ArtistsView = ({
     const data =
       artists ?? fetchedArtists?.pages.flatMap((page) => page?.data ?? []);
 
+    data?.sort((a, b) => a.name.localeCompare(b.name));
+
     return (
       data?.map((artist) => ({
         type: 'View',


### PR DESCRIPTION
This fixes #129, where the ArtistsView was out of order (at least with Spotify).