### PR TITLE
Add support for Bundle Analysis + minor optimizations

### DIFF
--- a/.gitignore
+++ b/.gitignore
@@ -11,6 +11,9 @@
 # production
 /build
 
+# TypeScript
+tsconfig.tsbuildinfo
+
 # misc
 .DS_Store
 .env.local

--- a/app/components/views/SearchView/index.tsx
+++ b/app/components/views/SearchView/index.tsx
@@ -19,6 +19,7 @@ import {
 } from "hooks";
 import { useFetchSearchResults } from "hooks/utils/useDataFetcher";
 import { APP_URL } from "utils/constants/api";
+import { pluralize } from "utils/strings";
 
 const SearchView = () => {
   useMenuHideView(viewConfigMap.search.id);
@@ -69,9 +70,11 @@ const SearchView = () => {
           <ArtistsView artists={artists} inLibrary={false} showImages />
         ),
         imageUrl: `${APP_URL}/artists_icon.svg`,
-        sublabel: `${artists?.length} ${
-          artists?.length === 1 ? "artist" : "artists"
-        }`,
+        sublabel: `${artists?.length} ${pluralize(
+          "artist",
+          "artists",
+          artists?.length
+        )}`,
       }),
       ...getConditionalOption(!!albums?.length, {
         type: "view",
@@ -79,9 +82,11 @@ const SearchView = () => {
         viewId: viewConfigMap.albums.id,
         component: () => <AlbumsView albums={albums} inLibrary={false} />,
         imageUrl: `${APP_URL}/albums_icon.svg`,
-        sublabel: `${albums?.length} ${
-          albums?.length === 1 ? "album" : "albums"
-        }`,
+        sublabel: `${albums?.length} ${pluralize(
+          "album",
+          "albums",
+          albums?.length
+        )}`,
       }),
       ...getConditionalOption(!!songs?.length, {
         type: "view",
@@ -89,7 +94,11 @@ const SearchView = () => {
         viewId: viewConfigMap.songs.id,
         component: () => <SongsView songs={songs!} />,
         imageUrl: `${APP_URL}/song_icon.svg`,
-        sublabel: `${songs?.length} ${songs?.length === 1 ? "song" : "songs"}`,
+        sublabel: `${songs?.length} ${pluralize(
+          "song",
+          "songs",
+          songs?.length
+        )}`,
       }),
       ...getConditionalOption(!!playlists?.length, {
         type: "view",
@@ -99,9 +108,11 @@ const SearchView = () => {
           <PlaylistsView playlists={playlists!} inLibrary={false} />
         ),
         imageUrl: `${APP_URL}/playlist_icon.svg`,
-        sublabel: `${playlists?.length} ${
-          playlists?.length === 1 ? "playlist" : "playlists"
-        }`,
+        sublabel: `${playlists?.length} ${pluralize(
+          "playlist",
+          "playlists",
+          playlists?.length
+        )}`,
       }),
     ];
 

--- a/app/components/views/SearchView/index.tsx
+++ b/app/components/views/SearchView/index.tsx
@@ -17,7 +17,6 @@ import {
   useScrollHandler,
   useSettings,
 } from "hooks";
-import pluralize from "pluralize";
 import { useFetchSearchResults } from "hooks/utils/useDataFetcher";
 import { APP_URL } from "utils/constants/api";
 
@@ -70,7 +69,9 @@ const SearchView = () => {
           <ArtistsView artists={artists} inLibrary={false} showImages />
         ),
         imageUrl: `${APP_URL}/artists_icon.svg`,
-        sublabel: `${artists?.length} ${pluralize("artist", artists?.length)}`,
+        sublabel: `${artists?.length} ${
+          artists?.length === 1 ? "artist" : "artists"
+        }`,
       }),
       ...getConditionalOption(!!albums?.length, {
         type: "view",
@@ -78,7 +79,9 @@ const SearchView = () => {
         viewId: viewConfigMap.albums.id,
         component: () => <AlbumsView albums={albums} inLibrary={false} />,
         imageUrl: `${APP_URL}/albums_icon.svg`,
-        sublabel: `${albums?.length} ${pluralize("album", albums?.length)}`,
+        sublabel: `${albums?.length} ${
+          albums?.length === 1 ? "album" : "albums"
+        }`,
       }),
       ...getConditionalOption(!!songs?.length, {
         type: "view",
@@ -86,7 +89,7 @@ const SearchView = () => {
         viewId: viewConfigMap.songs.id,
         component: () => <SongsView songs={songs!} />,
         imageUrl: `${APP_URL}/song_icon.svg`,
-        sublabel: `${songs?.length} ${pluralize("song", songs?.length)}`,
+        sublabel: `${songs?.length} ${songs?.length === 1 ? "song" : "songs"}`,
       }),
       ...getConditionalOption(!!playlists?.length, {
         type: "view",
@@ -96,10 +99,9 @@ const SearchView = () => {
           <PlaylistsView playlists={playlists!} inLibrary={false} />
         ),
         imageUrl: `${APP_URL}/playlist_icon.svg`,
-        sublabel: `${playlists?.length} ${pluralize(
-          "playlist",
-          playlists?.length
-        )}`,
+        sublabel: `${playlists?.length} ${
+          playlists?.length === 1 ? "playlist" : "playlists"
+        }`,
       }),
     ];
 

--- a/app/hooks/spotify/useSpotifyDataFetcher.ts
+++ b/app/hooks/spotify/useSpotifyDataFetcher.ts
@@ -127,13 +127,17 @@ const useSpotifyDataFetcher = () => {
         },
       });
 
-      const { default: uniqBy } = await import("lodash.uniqby");
-
       if (response) {
-        return uniqBy(
-          response.items.map(ConversionUtils.convertSpotifyAlbumSimplified),
-          (item) => item.name
-        );
+        const albumSet = new Set();
+        return response.items
+          .map(ConversionUtils.convertSpotifyAlbumSimplified)
+          .filter((album) => {
+            if (albumSet.has(album.name)) {
+              return false;
+            }
+            albumSet.add(album.name);
+            return true;
+          });
       }
     },
     [accessToken]

--- a/app/hooks/spotify/useSpotifyDataFetcher.ts
+++ b/app/hooks/spotify/useSpotifyDataFetcher.ts
@@ -1,7 +1,6 @@
 import { useCallback } from "react";
 
 import { useSpotifySDK } from "hooks";
-import uniqBy from "lodash.uniqby";
 import * as ConversionUtils from "utils/conversion";
 import querystring from "query-string";
 
@@ -128,6 +127,8 @@ const useSpotifyDataFetcher = () => {
         },
       });
 
+      const { default: uniqBy } = await import("lodash.uniqby");
+
       if (response) {
         return uniqBy(
           response.items.map(ConversionUtils.convertSpotifyAlbumSimplified),
@@ -155,11 +156,14 @@ const useSpotifyDataFetcher = () => {
           },
         });
 
+      const resultData = await Promise.all(
+        response?.items?.map(
+          ConversionUtils.convertSpotifyPlaylistSimplified
+        ) ?? []
+      );
+
       const result: MediaApi.PaginatedResponse<MediaApi.Playlist[]> = {
-        data:
-          response?.items?.map(
-            ConversionUtils.convertSpotifyPlaylistSimplified
-          ) ?? [],
+        data: resultData,
         nextPageParam: response?.next ? pageParam + 1 : undefined,
       };
 

--- a/app/hooks/spotify/useSpotifyDataFetcher.ts
+++ b/app/hooks/spotify/useSpotifyDataFetcher.ts
@@ -128,16 +128,17 @@ const useSpotifyDataFetcher = () => {
       });
 
       if (response) {
-        const albumSet = new Set();
+        // Keep track of the artist's albums, to avoid showing duplicates
+        const artistAlbums = new Set();
         return response.items
-          .map(ConversionUtils.convertSpotifyAlbumSimplified)
           .filter((album) => {
-            if (albumSet.has(album.name)) {
+            if (artistAlbums.has(album.name)) {
               return false;
             }
-            albumSet.add(album.name);
+            artistAlbums.add(album.name);
             return true;
-          });
+          })
+          .map(ConversionUtils.convertSpotifyAlbumSimplified);
       }
     },
     [accessToken]

--- a/app/utils/strings.ts
+++ b/app/utils/strings.ts
@@ -1,0 +1,10 @@
+export function pluralize(
+  singular: string,
+  plural: string,
+  count: number | undefined
+) {
+  if (count === 1) {
+    return singular;
+  }
+  return plural;
+}

--- a/next.config.js
+++ b/next.config.js
@@ -1,7 +1,11 @@
+const withBundleAnalyzer = require("@next/bundle-analyzer")({
+  enabled: process.env.ANALYZE === "true",
+});
+
 /** @type {import('next').NextConfig} */
 const nextConfig = {
   reactStrictMode: false,
   basePath: "/ipod",
 };
 
-module.exports = nextConfig;
+module.exports = withBundleAnalyzer(nextConfig);

--- a/package.json
+++ b/package.json
@@ -22,7 +22,6 @@
     "date-fns": "^3.2.0",
     "framer-motion": "^10.16.16",
     "he": "^1.2.0",
-    "lodash.uniqby": "^4.7.0",
     "long-press-event": "^2.4.4",
     "next": "^14.0.4",
     "query-string": "^7.1.1",

--- a/package.json
+++ b/package.json
@@ -6,8 +6,10 @@
   "scripts": {
     "dev": "NODE_OPTIONS='--inspect' next dev",
     "build": "next build",
+    "bundle-report": "ANALYZE=true yarn build",
     "start": "vercel dev",
-    "lint": "next lint"
+    "lint": "next lint",
+    "type-check": "tsc"
   },
   "eslintConfig": {
     "extends": "eslint-config-next"
@@ -23,8 +25,6 @@
     "lodash.uniqby": "^4.7.0",
     "long-press-event": "^2.4.4",
     "next": "^14.0.4",
-    "pluralize": "^8.0.0",
-    "prettier": "^2.7.1",
     "query-string": "^7.1.1",
     "react": "^18.2.0",
     "react-dom": "^18.2.0",
@@ -45,6 +45,7 @@
     "@types/spotify-web-playback-sdk": "^0.1.12",
     "@types/styled-components": "^5.1.25",
     "@types/uuid": "^9.0.7",
+    "@next/bundle-analyzer": "^14.0.4",
     "eslint": "8.26.0",
     "eslint-config-next": "^14.0.4",
     "eslint-plugin-import": "^2.26.0",
@@ -52,6 +53,7 @@
     "eslint-plugin-react-hooks": "^4.6.0",
     "eslint-plugin-react-memo": "^0.0.3",
     "eslint-plugin-unused-imports": "^2.0.0",
-    "typescript": "4.7.4"
+    "prettier": "^2.7.1",
+    "typescript": "5.3.3"
   }
 }

--- a/yarn.lock
+++ b/yarn.lock
@@ -2022,11 +2022,6 @@ lodash.merge@^4.6.2:
   resolved "https://registry.yarnpkg.com/lodash.merge/-/lodash.merge-4.6.2.tgz#558aa53b43b661e1925a0afdfa36a9a1085fe57a"
   integrity sha512-0KpjqXRVvrYyCsX1swR/XTK0va6VQkQM6MNo7PqW77ByjAhoARA8EfrP1N4+KlKj8YS0ZUCtRT/YUuhyYDujIQ==
 
-lodash.uniqby@^4.7.0:
-  version "4.7.0"
-  resolved "https://registry.yarnpkg.com/lodash.uniqby/-/lodash.uniqby-4.7.0.tgz#d99c07a669e9e6d24e1362dfe266c67616af1302"
-  integrity sha512-e/zcLx6CSbmaEgFHCA7BnoQKyCtKMxnuWrJygbwPs/AIn+IMKl66L8/s+wBUn5LRw2pZx3bUHibiV1b6aTWIww==
-
 lodash@^4.17.20:
   version "4.17.21"
   resolved "https://registry.npmjs.org/lodash/-/lodash-4.17.21.tgz#679591c564c3bffaae8454cf0b3df370c3d6911c"

--- a/yarn.lock
+++ b/yarn.lock
@@ -72,6 +72,13 @@
   resolved "https://registry.yarnpkg.com/@humanwhocodes/object-schema/-/object-schema-1.2.1.tgz#b520529ec21d8e5945a1851dfd1c32e94e39ff45"
   integrity sha512-ZnQMnLV4e7hDlUvw8H+U8ASL02SS2Gn6+9Ac3wGGLIe7+je2AeAOxPY+izIPJDfFDb7eDjev0Us8MO1iFRN8hA==
 
+"@next/bundle-analyzer@^14.0.4":
+  version "14.0.4"
+  resolved "https://registry.npmjs.org/@next/bundle-analyzer/-/bundle-analyzer-14.0.4.tgz#12672238b8ee48dd7cfa253f024374690bde6991"
+  integrity sha512-Nn2PiCkFBJBlVmpSGVNItpISws0fuc9E8AkCafBz/moRv1cfASOpFBBVzSRfWLP9BPdAhfDkb6TafN0rvs2IJQ==
+  dependencies:
+    webpack-bundle-analyzer "4.7.0"
+
 "@next/env@14.0.4":
   version "14.0.4"
   resolved "https://registry.yarnpkg.com/@next/env/-/env-14.0.4.tgz#d5cda0c4a862d70ae760e58c0cd96a8899a2e49a"
@@ -149,6 +156,11 @@
   dependencies:
     "@nodelib/fs.scandir" "2.1.5"
     fastq "^1.6.0"
+
+"@polka/url@^1.0.0-next.20":
+  version "1.0.0-next.24"
+  resolved "https://registry.npmjs.org/@polka/url/-/url-1.0.0-next.24.tgz#58601079e11784d20f82d0585865bb42305c4df3"
+  integrity sha512-2LuNTFBIO0m7kKIQvvPHN6UE63VjpmL9rnEEaOOaiSPbZK+zUOYIzBAWcED+3XYzhYsd/0mD57VdxAEqqV52CQ==
 
 "@rushstack/eslint-patch@^1.3.3":
   version "1.6.1"
@@ -346,6 +358,16 @@ acorn-jsx@^5.3.2:
   version "5.3.2"
   resolved "https://registry.yarnpkg.com/acorn-jsx/-/acorn-jsx-5.3.2.tgz#7ed5bb55908b3b2f1bc55c6af1653bada7f07937"
   integrity sha512-rq9s+JNhf0IChjtDXxllJ7g41oZk5SlXtp0LHwyA5cejwn7vKmKp4pPri6YEePv2PU65sAsegbXtIinmDFDXgQ==
+
+acorn-walk@^8.0.0:
+  version "8.3.2"
+  resolved "https://registry.npmjs.org/acorn-walk/-/acorn-walk-8.3.2.tgz#7703af9415f1b6db9315d6895503862e231d34aa"
+  integrity sha512-cjkyv4OtNCIeqhHrfS81QWXoCBPExR/J62oyEqepVw8WaQeSqpW2uhuLPh1m9eWhDuOo/jUXVTlifvesOWp/4A==
+
+acorn@^8.0.4:
+  version "8.11.3"
+  resolved "https://registry.npmjs.org/acorn/-/acorn-8.11.3.tgz#71e0b14e13a4ec160724b38fb7b0f233b1b81d7a"
+  integrity sha512-Y9rRfJG5jcKOE0CLisYbojUjIrIEE7AGMzA/Sm4BslANhbS+cDMpgBdcPT91oJ7OuJ9hYJBx59RjbhxVnrF8Xg==
 
 acorn@^8.8.0:
   version "8.8.1"
@@ -615,7 +637,7 @@ caniuse-lite@^1.0.30001406:
   resolved "https://registry.yarnpkg.com/caniuse-lite/-/caniuse-lite-1.0.30001576.tgz#893be772cf8ee6056d6c1e2d07df365b9ec0a5c4"
   integrity sha512-ff5BdakGe2P3SQsMsiqmt1Lc8221NR1VzHj5jXN5vBny9A6fpze94HiVV/n7XRosOlsShJcvMv5mdnpjOGCEgg==
 
-chalk@^4.0.0:
+chalk@^4.0.0, chalk@^4.1.0:
   version "4.1.2"
   resolved "https://registry.npmjs.org/chalk/-/chalk-4.1.2.tgz#aac4e2b7734a740867aeb16bf02aad556a1e7a01"
   integrity sha512-oKnbhFyRIXpUuez8iBMmyEa4nbj4IOQyuhc/wy9kY7/WVPcwIO9VA668Pu8RkO7+0G76SLROeyw9CpQ061i4mA==
@@ -646,6 +668,11 @@ combined-stream@^1.0.8:
   integrity sha512-FQN4MRfuJeHf7cBbBMJFXhKSDq+2kAArBlmRBvcvFE5BB1HZKXtSFASDhdlz9zOYwxh8lDdnvmMOe/+5cdoEdg==
   dependencies:
     delayed-stream "~1.0.0"
+
+commander@^7.2.0:
+  version "7.2.0"
+  resolved "https://registry.npmjs.org/commander/-/commander-7.2.0.tgz#a36cb57d0b501ce108e4d20559a150a391d97ab7"
+  integrity sha512-QrWXB+ZQSVPmIWIhtEO9H+gwHaMGYiF5ChvoJ+K9ZGHG/sVsa6yiesAD1GC/x46sET00Xlwo1u49RVVVzvcSkw==
 
 concat-map@0.0.1:
   version "0.0.1"
@@ -815,6 +842,11 @@ doctrine@^3.0.0:
   integrity sha512-yS+Q5i3hBf7GBkd4KG8a7eBNNWNGLTaEwwYWUijIYM7zrlYDM0BFXHjjPWlWZ1Rg7UaddZeIDmi9jF3HmqiQ2w==
   dependencies:
     esutils "^2.0.2"
+
+duplexer@^0.1.2:
+  version "0.1.2"
+  resolved "https://registry.npmjs.org/duplexer/-/duplexer-0.1.2.tgz#3abe43aef3835f8ae077d136ddce0f276b0400e6"
+  integrity sha512-jtD6YG370ZCIi/9GTaJKQxWTZD045+4R4hTk/x1UyoqadyJ9x9CgSi1RlVDQF8U2sxLLSnFkCaMihqljHIWgMg==
 
 emoji-regex@^9.2.2:
   version "9.2.2"
@@ -1583,6 +1615,13 @@ grapheme-splitter@^1.0.4:
   resolved "https://registry.yarnpkg.com/grapheme-splitter/-/grapheme-splitter-1.0.4.tgz#9cf3a665c6247479896834af35cf1dbb4400767e"
   integrity sha512-bzh50DW9kTPM00T8y4o8vQg89Di9oLJVLW/KaOGIXJWP/iqCN6WKYkbNOF04vFLJhwcpYUh9ydh/+5vpOqV4YQ==
 
+gzip-size@^6.0.0:
+  version "6.0.0"
+  resolved "https://registry.npmjs.org/gzip-size/-/gzip-size-6.0.0.tgz#065367fd50c239c0671cbcbad5be3e2eeb10e462"
+  integrity sha512-ax7ZYomf6jqPTQ4+XCpUGyXKHk5WweS+e05MBO4/y3WJ5RkmPXNKvX+bx1behVILVwr6JSQvZAku021CHPXG3Q==
+  dependencies:
+    duplexer "^0.1.2"
+
 has-bigints@^1.0.1, has-bigints@^1.0.2:
   version "1.0.2"
   resolved "https://registry.yarnpkg.com/has-bigints/-/has-bigints-1.0.2.tgz#0871bd3e3d51626f6ca0966668ba35d5602d6eaa"
@@ -1988,6 +2027,11 @@ lodash.uniqby@^4.7.0:
   resolved "https://registry.yarnpkg.com/lodash.uniqby/-/lodash.uniqby-4.7.0.tgz#d99c07a669e9e6d24e1362dfe266c67616af1302"
   integrity sha512-e/zcLx6CSbmaEgFHCA7BnoQKyCtKMxnuWrJygbwPs/AIn+IMKl66L8/s+wBUn5LRw2pZx3bUHibiV1b6aTWIww==
 
+lodash@^4.17.20:
+  version "4.17.21"
+  resolved "https://registry.npmjs.org/lodash/-/lodash-4.17.21.tgz#679591c564c3bffaae8454cf0b3df370c3d6911c"
+  integrity sha512-v2kDEe57lecTulaDIuNTPy3Ry4gLGJ6Z1O3vE1krgXZNrsQ+LFTGHVxVjcXPs17LhbZVGedAJv8XZ1tvj5FvSg==
+
 long-press-event@^2.4.4:
   version "2.4.4"
   resolved "https://registry.yarnpkg.com/long-press-event/-/long-press-event-2.4.4.tgz#0d517df8915b4c849ff0f99a28013960a7df6413"
@@ -2050,6 +2094,11 @@ minimist@^1.2.0, minimist@^1.2.6:
   version "1.2.6"
   resolved "https://registry.yarnpkg.com/minimist/-/minimist-1.2.6.tgz#8637a5b759ea0d6e98702cfb3a9283323c93af44"
   integrity sha512-Jsjnk4bw3YJqYzbdyBiNsPWHPfO++UGG749Cxs6peCu5Xg4nrena6OVxOYxrQTqww0Jmwt+Ref8rggumkTLz9Q==
+
+mrmime@^1.0.0:
+  version "1.0.1"
+  resolved "https://registry.npmjs.org/mrmime/-/mrmime-1.0.1.tgz#5f90c825fad4bdd41dc914eff5d1a8cfdaf24f27"
+  integrity sha512-hzzEagAgDyoU1Q6yg5uI+AorQgdvMCur3FcKf7NhMKWsaYg+RnbTyHRa/9IlLF9rf455MOCtcqqrQQ83pPP7Uw==
 
 ms@2.0.0:
   version "2.0.0"
@@ -2228,6 +2277,11 @@ once@^1.3.0:
   dependencies:
     wrappy "1"
 
+opener@^1.5.2:
+  version "1.5.2"
+  resolved "https://registry.npmjs.org/opener/-/opener-1.5.2.tgz#5d37e1f35077b9dcac4301372271afdeb2a13598"
+  integrity sha512-ur5UIdyw5Y7yEj9wLzhqXiy6GZ3Mwx0yGI+5sMn2r0N0v3cKJvUmFH5yPP+WXh9e0xfyzyJX95D8l088DNFj7A==
+
 optionator@^0.9.1:
   version "0.9.1"
   resolved "https://registry.yarnpkg.com/optionator/-/optionator-0.9.1.tgz#4f236a6373dae0566a6d43e1326674f50c291499"
@@ -2319,11 +2373,6 @@ picomatch@^2.3.1:
   version "2.3.1"
   resolved "https://registry.yarnpkg.com/picomatch/-/picomatch-2.3.1.tgz#3ba3833733646d9d3e4995946c1365a67fb07a42"
   integrity sha512-JU3teHTNjmE2VCGFzuY8EXzCDVwEqB2a8fsIvwaStHhAWJEeVd1o1QD80CU6+ZdEXXSLbSsuLwJjkCBWqRQUVA==
-
-pluralize@^8.0.0:
-  version "8.0.0"
-  resolved "https://registry.yarnpkg.com/pluralize/-/pluralize-8.0.0.tgz#1a6fa16a38d12a1901e0320fa017051c539ce3b1"
-  integrity sha512-Nc3IT5yHzflTfbjgqWcCPpo7DaKy4FnpB0l/zCAW0Tc7jxAiuqSxHasntB3D7887LSrA93kDJ9IXovxJYxyLCA==
 
 postcss-value-parser@^4.0.2:
   version "4.2.0"
@@ -2600,6 +2649,15 @@ side-channel@^1.0.4:
     get-intrinsic "^1.0.2"
     object-inspect "^1.9.0"
 
+sirv@^1.0.7:
+  version "1.0.19"
+  resolved "https://registry.npmjs.org/sirv/-/sirv-1.0.19.tgz#1d73979b38c7fe91fcba49c85280daa9c2363b49"
+  integrity sha512-JuLThK3TnZG1TAKDwNIqNq6QA2afLOCcm+iE8D1Kj3GA40pSPsxQjjJl0J8X3tsR7T+CP1GavpzLwYkgVLWrZQ==
+  dependencies:
+    "@polka/url" "^1.0.0-next.20"
+    mrmime "^1.0.0"
+    totalist "^1.0.0"
+
 slash@^3.0.0:
   version "3.0.0"
   resolved "https://registry.yarnpkg.com/slash/-/slash-3.0.0.tgz#6539be870c165adbd5240220dbe361f1bc4d4634"
@@ -2757,6 +2815,11 @@ to-regex-range@^5.0.1:
   dependencies:
     is-number "^7.0.0"
 
+totalist@^1.0.0:
+  version "1.1.0"
+  resolved "https://registry.npmjs.org/totalist/-/totalist-1.1.0.tgz#a4d65a3e546517701e3e5c37a47a70ac97fe56df"
+  integrity sha512-gduQwd1rOdDMGxFG1gEvhV88Oirdo2p+KjoYFU7k2g+i7n6AFFbDQ5kMPUsW0pNbfQsB/cwXvT1i4Bue0s9g5g==
+
 ts-api-utils@^1.0.1:
   version "1.0.3"
   resolved "https://registry.yarnpkg.com/ts-api-utils/-/ts-api-utils-1.0.3.tgz#f12c1c781d04427313dbac808f453f050e54a331"
@@ -2843,10 +2906,10 @@ typed-array-length@^1.0.4:
     for-each "^0.3.3"
     is-typed-array "^1.1.9"
 
-typescript@4.7.4:
-  version "4.7.4"
-  resolved "https://registry.yarnpkg.com/typescript/-/typescript-4.7.4.tgz#1a88596d1cf47d59507a1bcdfb5b9dfe4d488235"
-  integrity sha512-C0WQT0gezHuw6AdY1M2jxUO83Rjf0HP7Sk1DtXj6j1EwkQNZrHAg2XPWlq62oqEhYvONq5pkC2Y9oPljWToLmQ==
+typescript@5.3.3:
+  version "5.3.3"
+  resolved "https://registry.npmjs.org/typescript/-/typescript-5.3.3.tgz#b3ce6ba258e72e6305ba66f5c9b452aaee3ffe37"
+  integrity sha512-pXWcraxM0uxAS+tN0AG/BF2TyqmHO014Z070UsJ+pFvYuRSq8KH8DmWpnbXe0pEPDHXZV3FcAbJkijJ5oNEnWw==
 
 unbox-primitive@^1.0.2:
   version "1.0.2"
@@ -2887,6 +2950,21 @@ watchpack@2.4.0:
   dependencies:
     glob-to-regexp "^0.4.1"
     graceful-fs "^4.1.2"
+
+webpack-bundle-analyzer@4.7.0:
+  version "4.7.0"
+  resolved "https://registry.npmjs.org/webpack-bundle-analyzer/-/webpack-bundle-analyzer-4.7.0.tgz#33c1c485a7fcae8627c547b5c3328b46de733c66"
+  integrity sha512-j9b8ynpJS4K+zfO5GGwsAcQX4ZHpWV+yRiHDiL+bE0XHJ8NiPYLTNVQdlFYWxtpg9lfAQNlwJg16J9AJtFSXRg==
+  dependencies:
+    acorn "^8.0.4"
+    acorn-walk "^8.0.0"
+    chalk "^4.1.0"
+    commander "^7.2.0"
+    gzip-size "^6.0.0"
+    lodash "^4.17.20"
+    opener "^1.5.2"
+    sirv "^1.0.7"
+    ws "^7.3.1"
 
 which-boxed-primitive@^1.0.2:
   version "1.0.2"
@@ -2954,6 +3032,11 @@ wrappy@1:
   version "1.0.2"
   resolved "https://registry.yarnpkg.com/wrappy/-/wrappy-1.0.2.tgz#b5243d8f3ec1aa35f1364605bc0d1036e30ab69f"
   integrity sha512-l4Sp/DRseor9wL6EvV2+TuQn63dMkPjZ/sp9XkghTEbV9KlPS1xUsZ3u7/IQO4wxtcFB4bgpQPRcR3QCvezPcQ==
+
+ws@^7.3.1:
+  version "7.5.9"
+  resolved "https://registry.npmjs.org/ws/-/ws-7.5.9.tgz#54fa7db29f4c7cec68b1ddd3a89de099942bb591"
+  integrity sha512-F+P9Jil7UiSKSkppIiD94dN07AwvFixvLIj1Og1Rl9GGMuNipJnV9JzjD6XuqmAeiswGvUmNLjr5cFuXwNS77Q==
 
 yallist@^4.0.0:
   version "4.0.0"


### PR DESCRIPTION
Adding support for running `webpack-bundle-analyzer` on the project.

I noticed that the `he` package is only used by Spotify users, so I updated it to be dynamically imported. This will allow Apple Music users to avoid having to download the additional 29 KB.

I removed the `pluralize` and `lodash.uniqby` packages, which saved ~7 KB

## Before
<img width="1678" alt="Screenshot 2024-01-15 at 3 18 11 PM" src="https://github.com/tvillarete/ipod-classic-js/assets/1719443/31996b9f-588e-4350-916a-e165fd30ecf7">

## After
<img width="1680" alt="Screenshot 2024-01-15 at 4 03 33 PM" src="https://github.com/tvillarete/ipod-classic-js/assets/1719443/3f0a1673-9604-4ec5-b86f-2b83c8f0d7b2">
er

