### PR TITLE
Update @tanstack/react-query to latest version

### DIFF
--- a/app/hooks/utils/useDataFetcher.ts
+++ b/app/hooks/utils/useDataFetcher.ts
@@ -57,17 +57,17 @@ export const useFetchAlbum = (
   const { spotifyDataFetcher, appleDataFetcher, service, enabled } =
     useDataFetchers();
 
-  return useQuery(
-    ["album", { id: options.id }],
-    async () => {
+  return useQuery({
+    queryKey: ["album", { id: options.id }],
+    queryFn: async () => {
       if (service === "apple") {
         return appleDataFetcher.fetchAlbum(options.id, options.inLibrary);
       } else if (service === "spotify") {
         return spotifyDataFetcher.fetchAlbum({ id: options.id });
       }
     },
-    { enabled: enabled && !options.lazy }
-  );
+    enabled: enabled && !options.lazy,
+  });
 };
 
 export const useFetchAlbums = (
@@ -76,9 +76,9 @@ export const useFetchAlbums = (
   const { spotifyDataFetcher, appleDataFetcher, service, enabled } =
     useDataFetchers();
 
-  return useInfiniteQuery(
-    ["albums"],
-    async ({ pageParam = 0 }) => {
+  return useInfiniteQuery({
+    queryKey: ["albums"],
+    queryFn: async ({ pageParam }) => {
       const params = {
         pageParam,
         limit: 50,
@@ -90,24 +90,23 @@ export const useFetchAlbums = (
         return spotifyDataFetcher.fetchAlbums(params);
       }
     },
-    {
-      enabled: enabled && !options.lazy,
-      getNextPageParam: (lastPage) => lastPage?.nextPageParam,
-    }
-  );
+    enabled: enabled && !options.lazy,
+    getNextPageParam: (lastPage) => lastPage?.nextPageParam,
+    initialPageParam: 0,
+  });
 };
 
 export const useFetchArtists = (options: CommonFetcherProps) => {
   const { spotifyDataFetcher, appleDataFetcher, service, enabled } =
     useDataFetchers();
 
-  return useInfiniteQuery(
-    ["artists"],
-    async ({ pageParam = 0 }) => {
+  return useInfiniteQuery({
+    queryKey: ["artists"],
+    queryFn: async ({ pageParam }) => {
       const params = {
         pageParam,
         limit: 20,
-        after: pageParam,
+        after: `${pageParam}`,
       };
 
       if (service === "apple") {
@@ -116,13 +115,14 @@ export const useFetchArtists = (options: CommonFetcherProps) => {
         return spotifyDataFetcher.fetchArtists(params);
       }
     },
-    {
-      enabled: enabled && !options.lazy,
-      // TODO: Figure out a better way to deal with `after` param
-      getNextPageParam: (lastPage) =>
-        service === "spotify" ? lastPage?.after : lastPage?.nextPageParam,
-    }
-  );
+    enabled: enabled && !options.lazy,
+    // TODO: Figure out a better way to deal with `after` param
+    getNextPageParam: (lastPage) =>
+      service === "spotify"
+        ? (lastPage?.after as any)
+        : lastPage?.nextPageParam,
+    initialPageParam: 0,
+  });
 };
 
 export const useFetchArtistAlbums = (
@@ -131,9 +131,9 @@ export const useFetchArtistAlbums = (
   const { spotifyDataFetcher, appleDataFetcher, service, enabled } =
     useDataFetchers();
 
-  return useQuery(
-    ["artistAlbums", { id: options.id }],
-    async () => {
+  return useQuery({
+    queryKey: ["artistAlbums", { id: options.id }],
+    queryFn: async () => {
       if (service === "apple") {
         return appleDataFetcher.fetchArtistAlbums(
           options.id,
@@ -143,17 +143,17 @@ export const useFetchArtistAlbums = (
         return spotifyDataFetcher.fetchArtist(options.id);
       }
     },
-    { enabled: enabled && !options.lazy }
-  );
+    enabled: enabled && !options.lazy,
+  });
 };
 
 export const useFetchPlaylists = (options: CommonFetcherProps) => {
   const { spotifyDataFetcher, appleDataFetcher, service, enabled } =
     useDataFetchers();
 
-  return useInfiniteQuery(
-    ["playlists"],
-    async ({ pageParam = 0 }) => {
+  return useInfiniteQuery({
+    queryKey: ["playlists"],
+    queryFn: async ({ pageParam }) => {
       const params = {
         limit: 20,
         pageParam,
@@ -165,11 +165,10 @@ export const useFetchPlaylists = (options: CommonFetcherProps) => {
         return spotifyDataFetcher.fetchPlaylists(params);
       }
     },
-    {
-      enabled: enabled && !options.lazy,
-      getNextPageParam: (lastPage) => lastPage?.nextPageParam,
-    }
-  );
+    enabled: enabled && !options.lazy,
+    getNextPageParam: (lastPage) => lastPage?.nextPageParam,
+    initialPageParam: 0,
+  });
 };
 
 export const useFetchPlaylist = (
@@ -178,17 +177,17 @@ export const useFetchPlaylist = (
   const { spotifyDataFetcher, appleDataFetcher, service, enabled } =
     useDataFetchers();
 
-  return useQuery(
-    ["playlists", { id: options.id }],
-    async () => {
+  return useQuery({
+    queryKey: ["playlists", { id: options.id }],
+    queryFn: async () => {
       if (service === "apple") {
         return appleDataFetcher.fetchPlaylist(options.id, options.inLibrary);
       } else if (service === "spotify") {
         return spotifyDataFetcher.fetchPlaylist(options.id);
       }
     },
-    { enabled: enabled && !options.lazy }
-  );
+    enabled: enabled && !options.lazy,
+  });
 };
 
 export const useFetchSearchResults = (
@@ -197,15 +196,15 @@ export const useFetchSearchResults = (
   const { spotifyDataFetcher, appleDataFetcher, service, enabled } =
     useDataFetchers();
 
-  return useQuery(
-    ["search", { query: options.query }],
-    async () => {
+  return useQuery({
+    queryKey: ["search", { query: options.query }],
+    queryFn: async () => {
       if (service === "spotify") {
         return spotifyDataFetcher.fetchSearchResults(options.query);
       } else if (service === "apple") {
         return appleDataFetcher.fetchSearchResults(options.query);
       }
     },
-    { enabled: enabled && !options.lazy }
-  );
+    enabled: enabled && !options.lazy,
+  });
 };

--- a/package.json
+++ b/package.json
@@ -13,7 +13,7 @@
     "extends": "eslint-config-next"
   },
   "dependencies": {
-    "@tanstack/react-query": "^4.0.10",
+    "@tanstack/react-query": "^5.17.12",
     "axios": "^0.27.2",
     "cookie": "^0.5.0",
     "cookies-next": "^4.1.0",

--- a/yarn.lock
+++ b/yarn.lock
@@ -162,19 +162,17 @@
   dependencies:
     tslib "^2.4.0"
 
-"@tanstack/query-core@^4.0.0-beta.1":
-  version "4.0.10"
-  resolved "https://registry.npmjs.org/@tanstack/query-core/-/query-core-4.0.10.tgz#cae6f818006616dc72c95c863592f5f68b47548a"
-  integrity sha512-9LsABpZXkWZHi4P1ozRETEDXQocLAxVzQaIhganxbNuz/uA3PsCAJxJTiQrknG5htLMzOF5MqM9G10e6DCxV1A==
+"@tanstack/query-core@5.17.10":
+  version "5.17.10"
+  resolved "https://registry.npmjs.org/@tanstack/query-core/-/query-core-5.17.10.tgz#8b799f4a973ca1e2da8936b27aadc472900e6f36"
+  integrity sha512-bJ2oQUDBftvHcEkLS3gyzzShSeZpJyzNNRu8oHK13iNdsofyaDXtNO/c1Zy/PZYVX+PhqOXwoT42gMiEMRSSfQ==
 
-"@tanstack/react-query@^4.0.10":
-  version "4.0.10"
-  resolved "https://registry.npmjs.org/@tanstack/react-query/-/react-query-4.0.10.tgz#92c71a2632c06450d848d4964959bd216cde03c0"
-  integrity sha512-Wn5QhZUE5wvr6rGClV7KeQIUsdTmYR9mgmMZen7DSRWauHW2UTynFg3Kkf6pw+XlxxOLsyLWwz/Q6q1lSpM3TQ==
+"@tanstack/react-query@^5.17.12":
+  version "5.17.12"
+  resolved "https://registry.npmjs.org/@tanstack/react-query/-/react-query-5.17.12.tgz#7d5c05615f02a5f27a792e4a8019a85c86630d00"
+  integrity sha512-mJQ+3da1ug4t9b+GycUuNzMs5hd6t+F4tJ1hqyaN/dlETP+bWwYwrv2GXFIbZIfI1K1Hu+XWZ6HUhRPbNtZ4QQ==
   dependencies:
-    "@tanstack/query-core" "^4.0.0-beta.1"
-    "@types/use-sync-external-store" "^0.0.3"
-    use-sync-external-store "^1.2.0"
+    "@tanstack/query-core" "5.17.10"
 
 "@types/cookie@^0.4.1":
   version "0.4.1"
@@ -285,11 +283,6 @@
   version "4.2.5"
   resolved "https://registry.yarnpkg.com/@types/stylis/-/stylis-4.2.5.tgz#1daa6456f40959d06157698a653a9ab0a70281df"
   integrity sha512-1Xve+NMN7FWjY14vLoY5tL3BVEQ/n42YLwaqJIPYhotZ9uBHt87VceMwWQpzmdEt2TNXIorIFG+YeCUUW7RInw==
-
-"@types/use-sync-external-store@^0.0.3":
-  version "0.0.3"
-  resolved "https://registry.npmjs.org/@types/use-sync-external-store/-/use-sync-external-store-0.0.3.tgz#b6725d5f4af24ace33b36fafd295136e75509f43"
-  integrity sha512-EwmlvuaxPNej9+T4v5AuBPJa2x2UOJVdjCtDHgcDqitUeOtjnJKJ+apYjVcAoBEMjKW1VVFGZLUb5+qqa09XFA==
 
 "@types/uuid@^9.0.7":
   version "9.0.7"
@@ -2869,11 +2862,6 @@ use-debounce@^8.0.2:
   version "8.0.2"
   resolved "https://registry.yarnpkg.com/use-debounce/-/use-debounce-8.0.2.tgz#bd1b522c7b5b5d9dc249824fd2e4c3e4137b1ea9"
   integrity sha512-4yCQ4FmlmYNpcHXJk1E19chO1X58fH4+QrwKpa5nkx3d7szHR3MjheRgECLvHivp3ClUqEom+SHOGB9zBz+qlw==
-
-use-sync-external-store@^1.2.0:
-  version "1.2.0"
-  resolved "https://registry.npmjs.org/use-sync-external-store/-/use-sync-external-store-1.2.0.tgz#7dbefd6ef3fe4e767a0cf5d7287aacfb5846928a"
-  integrity sha512-eEgnFxGQ1Ife9bzYs6VLi8/4X6CObHMw9Qr9tPY43iKwsPw8xE8+EFsf/2cFZ5S3esXgpWgtSCtLNS41F+sKPA==
 
 uuid@^9.0.1:
   version "9.0.1"


### PR DESCRIPTION
We're a major version behind on `@tanstack/react-query`. Let's get up to the latest version.

Before merging, we'll have to go through the Migration Guide to make sure things look good to go:
https://tanstack.com/query/v5/docs/react/guides/migrating-to-v5