### PR TITLE
Remove date-fns dependency

### DIFF
--- a/app/utils/index.ts
+++ b/app/utils/index.ts
@@ -1,5 +1,4 @@
 import { SelectableListOption } from "components/SelectableList";
-import { format, set } from "date-fns";
 import { DEFAULT_ARTWORK_URL } from "utils/constants/api";
 
 /** Accepts a url with '{w}' and '{h}' and replaces them with the specified size */
@@ -45,15 +44,14 @@ export const getMediaOptions = (
   ];
 };
 
-export const formatPlaybackTime = (seconds: number) =>
-  format(
-    set(new Date(), {
-      hours: 0,
-      minutes: 0,
-      seconds,
-    }),
-    "mm:ss"
-  );
+export const formatPlaybackTime = (seconds: number) => {
+  const dateObject = new Date();
+  dateObject.setMinutes(0);
+  dateObject.setSeconds(seconds);
+  const formattedMinutes = dateObject.getMinutes().toString().padStart(2, "0");
+  const formattedSeconds = dateObject.getSeconds().toString().padStart(2, "0");
+  return `${formattedMinutes}:${formattedSeconds}`;
+};
 
 /**
  *

--- a/app/utils/spotify.ts
+++ b/app/utils/spotify.ts
@@ -1,4 +1,3 @@
-import { differenceInMinutes } from "date-fns";
 import { getRootAppUrl } from "utils";
 import { API_URL } from "utils/constants/api";
 import { SELECTED_SERVICE_KEY } from "utils/service";
@@ -28,10 +27,12 @@ export const checkShouldRefreshSpotifyTokens = (
     return true;
   }
 
-  const lastRefreshDate = new Date(lastRefreshedTimestamp);
+  const lastRefreshDate = new Date(lastRefreshedTimestamp).valueOf();
   const now = Date.now();
 
-  const minuteDiff = differenceInMinutes(now, lastRefreshDate);
+  const millisecondDiff = now - lastRefreshDate;
+  const millisecondsInMinute = 60 * 1000;
+  const minuteDiff = Math.trunc(millisecondDiff / millisecondsInMinute);
   console.log(`Last token refresh: ${minuteDiff} minutes ago`);
 
   return minuteDiff > 30;

--- a/package.json
+++ b/package.json
@@ -19,7 +19,6 @@
     "axios": "^0.27.2",
     "cookie": "^0.5.0",
     "cookies-next": "^4.1.0",
-    "date-fns": "^3.2.0",
     "framer-motion": "^10.16.16",
     "he": "^1.2.0",
     "long-press-event": "^2.4.4",

--- a/yarn.lock
+++ b/yarn.lock
@@ -729,11 +729,6 @@ damerau-levenshtein@^1.0.8:
   resolved "https://registry.yarnpkg.com/damerau-levenshtein/-/damerau-levenshtein-1.0.8.tgz#b43d286ccbd36bc5b2f7ed41caf2d0aba1f8a6e7"
   integrity sha512-sdQSFB7+llfUcQHUQO3+B8ERRj0Oa4w9POWMI/puGtuf7gFywGmkaLCElnudfTiKZV+NvHqL0ifzdrI8Ro7ESA==
 
-date-fns@^3.2.0:
-  version "3.2.0"
-  resolved "https://registry.yarnpkg.com/date-fns/-/date-fns-3.2.0.tgz#c97cf685b62c829aa4ecba554e4a51768cf0bffc"
-  integrity sha512-E4KWKavANzeuusPi0jUjpuI22SURAznGkx7eZV+4i6x2A+IZxAMcajgkvuDAU1bg40+xuhW1zRdVIIM/4khuIg==
-
 debug@^2.6.9:
   version "2.6.9"
   resolved "https://registry.npmjs.org/debug/-/debug-2.6.9.tgz#5d128515df134ff327e90a4c93f4e077a536341f"


### PR DESCRIPTION
Replacing usage of `date-fns` with native language features. Saves some bundle size (~5 KB) and removes a dependency from the project.

## Before
<img width="462" alt="Screenshot 2024-01-28 at 11 12 02 AM" src="https://github.com/tvillarete/ipod-classic-js/assets/1719443/7ce7fa10-3708-4f4e-9289-cfdd488a37bb">


## After
<img width="454" alt="Screenshot 2024-01-28 at 11 10 53 AM" src="https://github.com/tvillarete/ipod-classic-js/assets/1719443/e61534c0-9a0f-47cf-ac09-8a2e3c0f869b">

