### PR TITLE
Improvements to Spotify lists

### DIFF
--- a/app/components/views/ArtistsView/index.tsx
+++ b/app/components/views/ArtistsView/index.tsx
@@ -26,7 +26,13 @@ const ArtistsView = ({
 
   const options: SelectableListOption[] = useMemo(() => {
     const data =
-      artists ?? fetchedArtists?.pages.flatMap((page) => page?.data ?? []);
+      (artists ??
+        fetchedArtists?.pages.flatMap((page) => page?.data ??
+          [])?.sort(function (a, b) {
+            var artistNameA = a.name.toUpperCase();
+            var artistNameB = b.name.toUpperCase();
+            return (artistNameA < artistNameB) ? -1 : (artistNameA > artistNameB) ? 1 : 0;
+          }));
 
     return (
       data?.map(

--- a/app/components/views/PlaylistsView/index.tsx
+++ b/app/components/views/PlaylistsView/index.tsx
@@ -24,6 +24,7 @@ const PlaylistsView = ({ playlists, inLibrary = true }: Props) => {
     lazy: !!playlists,
   });
 
+  // @ts-ignore
   const options: SelectableListOption[] = useMemo(() => {
     const data =
       playlists ?? fetchedPlaylists?.pages.flatMap((page) => page?.data ?? []);

--- a/app/components/views/PlaylistsView/index.tsx
+++ b/app/components/views/PlaylistsView/index.tsx
@@ -40,7 +40,11 @@ const PlaylistsView = ({ playlists, inLibrary = true }: Props) => {
           <PlaylistView id={playlist.id} inLibrary={inLibrary} />
         ),
         longPressOptions: Utils.getMediaOptions("playlist", playlist.id),
-      })) ?? []
+      }))?.sort(function (a, b) {
+        var playlistNameA = a.label.toUpperCase();
+        var playlistNameB = b.label.toUpperCase();
+        return (playlistNameA < playlistNameB) ? -1 : (playlistNameA > playlistNameB) ? 1 : 0;
+      }) ?? []
     );
   }, [fetchedPlaylists?.pages, inLibrary, playlists]);
 

--- a/app/hooks/utils/useDataFetcher.ts
+++ b/app/hooks/utils/useDataFetcher.ts
@@ -105,7 +105,7 @@ export const useFetchArtists = (options: CommonFetcherProps) => {
     queryFn: async ({ pageParam }) => {
       const params = {
         pageParam,
-        limit: 20,
+        limit: 50,
         after: `${pageParam}`,
       };
 
@@ -155,7 +155,7 @@ export const useFetchPlaylists = (options: CommonFetcherProps) => {
     queryKey: ["playlists"],
     queryFn: async ({ pageParam }) => {
       const params = {
-        limit: 20,
+        limit: 50,
         pageParam,
       };
 


### PR DESCRIPTION
Hey, I really love this app, thanks for creating it! Recently I've been going back to basics which is great for mental health and focus. I use Spotify and encountered a few things I would like to improve. I appreciate your time to review and consider these 😊 

- App only pulls in the first 20 artists or playlists. Changed to pull in all artists and playlists. I didn't fully understand the pagination types, so I have used a while loop to achieve this.

- App does not list artists or playlists in alphabetical order. Changed to sort the lists alphabetically for ease of navigation.

![alphabetical-order](https://github.com/tvillarete/ipod-classic-js/assets/42714431/9cc07f13-a483-4598-876d-6f8784074787)

![alphabetical-order-artists](https://github.com/tvillarete/ipod-classic-js/assets/42714431/9bbbd598-ca20-47dc-933a-66f8cc4b0ae4)

- App only pulls in the first 20 albums. Increased the limit to 50 albums.

![increased-number-of-albums-returned](https://github.com/tvillarete/ipod-classic-js/assets/42714431/138fb7a4-6718-4264-9a98-443834169162)

I tested these on localhost, but couldn't login to Spotify after deploying to Vercel, maybe due to the authentication callback? Thanks again.