### PR TITLE
refactor: migrate to @/ import path aliases

### DIFF
--- a/app/api/spotify/callback/route.ts
+++ b/app/api/spotify/callback/route.ts
@@ -1,5 +1,5 @@
-import { SPOTIFY_CLIENT_ID, SPOTIFY_CLIENT_SECRET } from "utils/constants/api";
-import { getSpotifyRedirectUri, setSpotifyTokens } from "api/spotify/utils";
+import { SPOTIFY_CLIENT_ID, SPOTIFY_CLIENT_SECRET } from "@/utils/constants/api";
+import { getSpotifyRedirectUri, setSpotifyTokens } from "@/api/spotify/utils";
 import { NextRequest } from "next/server";
 
 type SpotifyAuthApiResponse = {

--- a/app/api/spotify/login/route.ts
+++ b/app/api/spotify/login/route.ts
@@ -1,5 +1,5 @@
-import { SPOTIFY_CLIENT_ID } from "utils/constants/api";
-import { getSpotifyRedirectUri } from "api/spotify/utils";
+import { SPOTIFY_CLIENT_ID } from "@/utils/constants/api";
+import { getSpotifyRedirectUri } from "@/api/spotify/utils";
 import { v4 as uuid } from "uuid";
 
 export async function GET() {

--- a/app/api/spotify/logout/route.ts
+++ b/app/api/spotify/logout/route.ts
@@ -1,4 +1,4 @@
-import { clearSpotifyTokens } from "api/spotify/utils";
+import { clearSpotifyTokens } from "@/api/spotify/utils";
 
 export async function GET() {
   clearSpotifyTokens();

--- a/app/api/spotify/refresh/route.ts
+++ b/app/api/spotify/refresh/route.ts
@@ -1,6 +1,6 @@
-import { SPOTIFY_CLIENT_ID, SPOTIFY_CLIENT_SECRET } from "utils/constants/api";
+import { SPOTIFY_CLIENT_ID, SPOTIFY_CLIENT_SECRET } from "@/utils/constants/api";
 import { NextRequest } from "next/server";
-import { setSpotifyTokens } from "api/spotify/utils";
+import { setSpotifyTokens } from "@/api/spotify/utils";
 
 export async function GET(req: NextRequest) {
   const url = new URL(req.url ?? "");

--- a/app/api/spotify/utils.ts
+++ b/app/api/spotify/utils.ts
@@ -1,6 +1,6 @@
 import { deleteCookie, getCookie, setCookie } from "cookies-next";
 import { cookies } from "next/headers";
-import { SPOTIFY_TOKENS_COOKIE_NAME } from "utils/constants/api";
+import { SPOTIFY_TOKENS_COOKIE_NAME } from "@/utils/constants/api";
 
 /**
  * [Server-side only] Returns the root URL of the app, depending on the environment

--- a/app/components/AuthPrompt/index.tsx
+++ b/app/components/AuthPrompt/index.tsx
@@ -1,9 +1,9 @@
 import { useState } from "react";
 
-import { useInterval, useMusicKit } from "hooks";
+import { useInterval, useMusicKit } from "@/hooks";
 import styled, { css } from "styled-components";
-import { Unit } from "utils/constants";
-import { APP_URL } from "utils/constants/api";
+import { Unit } from "@/utils/constants";
+import { APP_URL } from "@/utils/constants/api";
 
 const RootContainer = styled.div`
   display: grid;

--- a/app/components/BatteryIndicator/index.tsx
+++ b/app/components/BatteryIndicator/index.tsx
@@ -1,4 +1,4 @@
-import { useBattery } from "hooks/battery";
+import { useBattery } from "@/hooks/battery";
 import styled, { css } from "styled-components";
 import { Bolt } from "./icons/bolt";
 import { Plug } from "./icons/plug";

--- a/app/components/ClickWheel/index.tsx
+++ b/app/components/ClickWheel/index.tsx
@@ -13,8 +13,8 @@ import {
   getCircularBoundingInfo,
   getScrollDirection,
 } from "./helpers";
-import { DeviceThemeName, getTheme } from "utils/themes";
-import { useEventListener, useSettings } from "hooks";
+import { DeviceThemeName, getTheme } from "@/utils/themes";
+import { useEventListener, useSettings } from "@/hooks";
 import {
   dispatchBackClickEvent,
   dispatchCenterClickEvent,
@@ -24,9 +24,9 @@ import {
   dispatchMenuClickEvent,
   dispatchPlayPauseClickEvent,
   dispatchScrollEvent,
-} from "utils/events";
-import { useLongPressHandler } from "hooks/navigation/useLongPressHandler";
-import { Screen } from "utils/constants";
+} from "@/utils/events";
+import { useLongPressHandler } from "@/hooks/navigation/useLongPressHandler";
+import { Screen } from "@/utils/constants";
 import { ANGLE_OFFSET_THRESHOLD, PAN_THRESHOLD } from "./constants";
 
 type RootContainerProps = {

--- a/app/components/Controls/ProgressBar.tsx
+++ b/app/components/Controls/ProgressBar.tsx
@@ -1,5 +1,5 @@
 import styled from "styled-components";
-import { APP_URL } from "utils/constants/api";
+import { APP_URL } from "@/utils/constants/api";
 
 const Container = styled.div`
   position: relative;

--- a/app/components/Controls/Scrubber.tsx
+++ b/app/components/Controls/Scrubber.tsx
@@ -1,13 +1,13 @@
 import { useCallback, useMemo, useState } from "react";
 
-import { useAudioPlayer, useEventListener, useInterval } from "hooks";
+import { useAudioPlayer, useEventListener, useInterval } from "@/hooks";
 import styled from "styled-components";
 import { useDebouncedCallback } from "use-debounce";
-import { Unit } from "utils/constants";
+import { Unit } from "@/utils/constants";
 
 import ProgressBar from "./ProgressBar";
-import { IpodEvent } from "utils/events";
-import * as Utils from "utils";
+import { IpodEvent } from "@/utils/events";
+import * as Utils from "@/utils";
 
 const RootContainer = styled.div`
   position: relative;

--- a/app/components/Controls/TrackProgress.tsx
+++ b/app/components/Controls/TrackProgress.tsx
@@ -1,8 +1,8 @@
-import LoadingIndicator from "components/LoadingIndicator";
-import { useAudioPlayer, useInterval } from "hooks";
+import LoadingIndicator from "@/components/LoadingIndicator";
+import { useAudioPlayer, useInterval } from "@/hooks";
 import styled from "styled-components";
-import * as Utils from "utils";
-import { Unit } from "utils/constants";
+import * as Utils from "@/utils";
+import { Unit } from "@/utils/constants";
 
 import ProgressBar from "./ProgressBar";
 import { useMemo } from "react";

--- a/app/components/Controls/VolumeBar.tsx
+++ b/app/components/Controls/VolumeBar.tsx
@@ -1,8 +1,8 @@
 import styled from "styled-components";
-import { Unit } from "utils/constants";
+import { Unit } from "@/utils/constants";
 
 import ProgressBar from "./ProgressBar";
-import { APP_URL } from "utils/constants/api";
+import { APP_URL } from "@/utils/constants/api";
 
 const Container = styled.div`
   position: relative;

--- a/app/components/Controls/index.tsx
+++ b/app/components/Controls/index.tsx
@@ -1,13 +1,13 @@
 import { useCallback, useState } from "react";
 
-import { useEventListener, useVolumeHandler } from "hooks";
+import { useEventListener, useVolumeHandler } from "@/hooks";
 import styled from "styled-components";
-import { Unit } from "utils/constants";
+import { Unit } from "@/utils/constants";
 
 import Scrubber from "./Scrubber";
 import TrackProgress from "./TrackProgress";
 import VolumeBar from "./VolumeBar";
-import { IpodEvent } from "utils/events";
+import { IpodEvent } from "@/utils/events";
 
 const Container = styled.div`
   position: relative;

--- a/app/components/ErrorScreen/index.tsx
+++ b/app/components/ErrorScreen/index.tsx
@@ -1,6 +1,6 @@
-import { SadMacIcon } from "components/icons";
+import { SadMacIcon } from "@/components/icons";
 import styled from "styled-components";
-import { Unit } from "utils/constants";
+import { Unit } from "@/utils/constants";
 
 const RootContainer = styled.div`
   display: flex;

--- a/app/components/Header/index.tsx
+++ b/app/components/Header/index.tsx
@@ -1,8 +1,8 @@
-import BatteryIndicator from "components/BatteryIndicator";
-import LoadingIndicator from "components/LoadingIndicator";
-import { useAudioPlayer, useViewContext } from "hooks";
+import BatteryIndicator from "@/components/BatteryIndicator";
+import LoadingIndicator from "@/components/LoadingIndicator";
+import { useAudioPlayer, useViewContext } from "@/hooks";
 import styled from "styled-components";
-import { APP_URL } from "utils/constants/api";
+import { APP_URL } from "@/utils/constants/api";
 
 const Container = styled.div`
   width: 100%;

--- a/app/components/Ipod/GlobalStyles.ts
+++ b/app/components/Ipod/GlobalStyles.ts
@@ -1,5 +1,5 @@
 import { createGlobalStyle } from "styled-components";
-import { Screen } from "utils/constants";
+import { Screen } from "@/utils/constants";
 
 export const GlobalStyles = createGlobalStyle`
   body {

--- a/app/components/Ipod/Ipod.tsx
+++ b/app/components/Ipod/Ipod.tsx
@@ -1,13 +1,13 @@
 "use client";
 import { memo, useCallback, useState } from "react";
-import * as SpotifyUtils from "utils/spotify";
+import * as SpotifyUtils from "@/utils/spotify";
 import {
   AudioPlayerProvider,
   SettingsContext,
   SettingsProvider,
   useEffectOnce,
-} from "hooks";
-import { ClickWheel, ViewManager } from "components";
+} from "@/hooks";
+import { ClickWheel, ViewManager } from "@/components";
 import {
   ScreenContainer,
   ClickWheelContainer,
@@ -15,13 +15,13 @@ import {
   Sticker,
   Sticker2,
   Sticker3,
-} from "components/Ipod/Styled";
+} from "@/components/Ipod/Styled";
 import { QueryClient, QueryClientProvider } from "@tanstack/react-query";
-import { SpotifySDKProvider } from "providers/SpotifySdkProvider";
-import { MusicKitProvider } from "providers/MusicKitProvider";
-import ViewContextProvider from "providers/ViewContextProvider";
+import { SpotifySDKProvider } from "@/providers/SpotifySdkProvider";
+import { MusicKitProvider } from "@/providers/MusicKitProvider";
+import ViewContextProvider from "@/providers/ViewContextProvider";
 import { useRouter } from "next/navigation";
-import { GlobalStyles } from "components/Ipod/GlobalStyles";
+import { GlobalStyles } from "@/components/Ipod/GlobalStyles";
 import Script from "next/script";
 
 type Props = {

--- a/app/components/Ipod/Styled/index.ts
+++ b/app/components/Ipod/Styled/index.ts
@@ -1,6 +1,6 @@
 import styled from "styled-components";
-import { Screen, Unit } from "utils/constants";
-import { DeviceThemeName, getTheme } from "utils/themes";
+import { Screen, Unit } from "@/utils/constants";
+import { DeviceThemeName, getTheme } from "@/utils/themes";
 
 export const Shell = styled.div<{ $deviceTheme: DeviceThemeName }>`
   position: relative;

--- a/app/components/KenBurns/index.tsx
+++ b/app/components/KenBurns/index.tsx
@@ -1,6 +1,6 @@
 import { useCallback, useEffect, useRef, useState } from "react";
 
-import { useInterval } from "hooks";
+import { useInterval } from "@/hooks";
 import styled from "styled-components";
 
 const Container = styled.div``;

--- a/app/components/LoadingScreen/index.tsx
+++ b/app/components/LoadingScreen/index.tsx
@@ -1,4 +1,4 @@
-import { fade } from "animation";
+import { fade } from "@/animation";
 import { motion } from "framer-motion";
 import styled from "styled-components";
 

--- a/app/components/NowPlaying/index.tsx
+++ b/app/components/NowPlaying/index.tsx
@@ -1,10 +1,10 @@
 import { useCallback } from "react";
 
-import { Controls } from "components";
-import { useAudioPlayer, useEffectOnce, useMKEventListener } from "hooks";
+import { Controls } from "@/components";
+import { useAudioPlayer, useEffectOnce, useMKEventListener } from "@/hooks";
 import styled from "styled-components";
-import { Unit } from "utils/constants";
-import * as Utils from "utils";
+import { Unit } from "@/utils/constants";
+import * as Utils from "@/utils";
 
 const Container = styled.div`
   height: 100%;

--- a/app/components/SelectableList/SelectableListItem.tsx
+++ b/app/components/SelectableList/SelectableListItem.tsx
@@ -1,8 +1,8 @@
 import styled, { css } from "styled-components";
-import { Unit } from "utils/constants";
+import { Unit } from "@/utils/constants";
 
 import { SelectableListOption } from ".";
-import { APP_URL } from "utils/constants/api";
+import { APP_URL } from "@/utils/constants/api";
 
 const LabelContainer = styled.div`
   flex: 1;

--- a/app/components/SelectableList/index.tsx
+++ b/app/components/SelectableList/index.tsx
@@ -1,10 +1,10 @@
 import { useEffect, useMemo, useRef, useState } from "react";
 
-import { LoadingIndicator, LoadingScreen } from "components";
-import ErrorScreen from "components/ErrorScreen";
-import { SplitScreenPreview } from "components/previews";
+import { LoadingIndicator, LoadingScreen } from "@/components";
+import ErrorScreen from "@/components/ErrorScreen";
+import { SplitScreenPreview } from "@/components/previews";
 import { AnimatePresence, motion } from "framer-motion";
-import { useTimeout } from "hooks";
+import { useTimeout } from "@/hooks";
 import styled from "styled-components";
 
 import SelectableListItem from "./SelectableListItem";

--- a/app/components/ViewManager/ActionSheetViewManager/index.tsx
+++ b/app/components/ViewManager/ActionSheetViewManager/index.tsx
@@ -2,7 +2,7 @@ import { AnimatePresence } from "framer-motion";
 import styled from "styled-components";
 
 import ActionSheet from "../components/ActionSheet";
-import { ViewOptions } from "providers/ViewContextProvider";
+import { ViewOptions } from "@/providers/ViewContextProvider";
 
 interface ContainerProps {
   $isHidden: boolean;

--- a/app/components/ViewManager/CoverFlowViewManager/index.tsx
+++ b/app/components/ViewManager/CoverFlowViewManager/index.tsx
@@ -1,7 +1,7 @@
-import { fade } from "animation";
-import { CoverFlowView, Header } from "components";
+import { fade } from "@/animation";
+import { CoverFlowView, Header } from "@/components";
 import { AnimatePresence, motion } from "framer-motion";
-import { ViewOptions } from "providers/ViewContextProvider";
+import { ViewOptions } from "@/providers/ViewContextProvider";
 import styled from "styled-components";
 
 const Container = styled(motion.div)`

--- a/app/components/ViewManager/FullScreenViewManager/index.tsx
+++ b/app/components/ViewManager/FullScreenViewManager/index.tsx
@@ -1,7 +1,7 @@
-import { Header } from "components";
-import View from "components/ViewManager/components/View";
+import { Header } from "@/components";
+import View from "@/components/ViewManager/components/View";
 import { AnimatePresence } from "framer-motion";
-import { ViewOptions } from "providers/ViewContextProvider";
+import { ViewOptions } from "@/providers/ViewContextProvider";
 import styled from "styled-components";
 
 interface ContainerProps {

--- a/app/components/ViewManager/KeyboardViewManager/index.tsx
+++ b/app/components/ViewManager/KeyboardViewManager/index.tsx
@@ -1,5 +1,5 @@
 import { AnimatePresence } from "framer-motion";
-import { ViewOptions } from "providers/ViewContextProvider";
+import { ViewOptions } from "@/providers/ViewContextProvider";
 import styled from "styled-components";
 
 import KeyboardInput from "../components/KeyboardInput";

--- a/app/components/ViewManager/PopupViewManager/index.tsx
+++ b/app/components/ViewManager/PopupViewManager/index.tsx
@@ -1,5 +1,5 @@
 import { AnimatePresence } from "framer-motion";
-import { ViewOptions } from "providers/ViewContextProvider";
+import { ViewOptions } from "@/providers/ViewContextProvider";
 import styled from "styled-components";
 
 import Popup from "../components/Popup";

--- a/app/components/ViewManager/SplitScreenViewManager/PreviewPanel.tsx
+++ b/app/components/ViewManager/SplitScreenViewManager/PreviewPanel.tsx
@@ -1,7 +1,7 @@
-import { SplitScreenPreview, Previews } from "components/previews";
+import { SplitScreenPreview, Previews } from "@/components/previews";
 import { AnimatePresence } from "framer-motion";
-import { useViewContext } from "hooks";
-import { Screen } from "utils/constants";
+import { useViewContext } from "@/hooks";
+import { Screen } from "@/utils/constants";
 import styled, { css } from "styled-components";
 
 interface ContainerProps {

--- a/app/components/ViewManager/SplitScreenViewManager/index.tsx
+++ b/app/components/ViewManager/SplitScreenViewManager/index.tsx
@@ -1,10 +1,10 @@
-import { Header } from "components";
-import PreviewPanel from "components/ViewManager/SplitScreenViewManager/PreviewPanel";
-import View from "components/ViewManager/components/View";
+import { Header } from "@/components";
+import PreviewPanel from "@/components/ViewManager/SplitScreenViewManager/PreviewPanel";
+import View from "@/components/ViewManager/components/View";
 import { AnimatePresence } from "framer-motion";
-import { ViewOptions } from "providers/ViewContextProvider";
+import { ViewOptions } from "@/providers/ViewContextProvider";
 import styled, { css } from "styled-components";
-import { Screen } from "utils/constants";
+import { Screen } from "@/utils/constants";
 
 const Container = styled.div`
   z-index: 2;

--- a/app/components/ViewManager/components/ActionSheet.tsx
+++ b/app/components/ViewManager/components/ActionSheet.tsx
@@ -1,18 +1,18 @@
 import { useMemo } from "react";
 
-import { SelectableListOption } from "components";
+import { SelectableListOption } from "@/components";
 import { motion } from "framer-motion";
 import {
   useEventListener,
   useMenuHideView,
   useScrollHandler,
   useViewContext,
-} from "hooks";
+} from "@/hooks";
 import styled, { css } from "styled-components";
-import { Unit } from "utils/constants";
-import { IpodEvent } from "utils/events";
-import { ViewOptions } from "providers/ViewContextProvider";
-import { slideUpAnimation } from "animation";
+import { Unit } from "@/utils/constants";
+import { IpodEvent } from "@/utils/events";
+import { ViewOptions } from "@/providers/ViewContextProvider";
+import { slideUpAnimation } from "@/animation";
 
 interface RootContainerProps {
   index: number;

--- a/app/components/ViewManager/components/KeyboardInput.tsx
+++ b/app/components/ViewManager/components/KeyboardInput.tsx
@@ -1,12 +1,12 @@
 import { useCallback, useEffect, useMemo, useRef } from "react";
 
-import { popInAnimation } from "animation";
-import { SelectableListOption } from "components";
+import { popInAnimation } from "@/animation";
+import { SelectableListOption } from "@/components";
 import { motion } from "framer-motion";
-import { useKeyboardInput, useMenuHideView, useScrollHandler } from "hooks";
-import { ViewOptions } from "providers/ViewContextProvider";
+import { useKeyboardInput, useMenuHideView, useScrollHandler } from "@/hooks";
+import { ViewOptions } from "@/providers/ViewContextProvider";
 import styled, { css } from "styled-components";
-import { Unit } from "utils/constants";
+import { Unit } from "@/utils/constants";
 
 interface RootContainerProps {
 	index: number;

--- a/app/components/ViewManager/components/Popup.tsx
+++ b/app/components/ViewManager/components/Popup.tsx
@@ -1,18 +1,18 @@
 import { useMemo } from "react";
 
-import { popInAnimation } from "animation";
-import { SelectableListOption } from "components";
+import { popInAnimation } from "@/animation";
+import { SelectableListOption } from "@/components";
 import { motion } from "framer-motion";
 import {
   useEventListener,
   useMenuHideView,
   useScrollHandler,
   useViewContext,
-} from "hooks";
-import { ViewOptions } from "providers/ViewContextProvider";
+} from "@/hooks";
+import { ViewOptions } from "@/providers/ViewContextProvider";
 import styled, { css } from "styled-components";
-import { Unit } from "utils/constants";
-import { IpodEvent } from "utils/events";
+import { Unit } from "@/utils/constants";
+import { IpodEvent } from "@/utils/events";
 
 interface RootContainerProps {
   index: number;

--- a/app/components/ViewManager/components/View.tsx
+++ b/app/components/ViewManager/components/View.tsx
@@ -1,8 +1,8 @@
 import { useMemo } from "react";
 
-import { noAnimation, slideRightAnimation } from "animation";
+import { noAnimation, slideRightAnimation } from "@/animation";
 import { motion } from "framer-motion";
-import { ViewOptions } from "providers/ViewContextProvider";
+import { ViewOptions } from "@/providers/ViewContextProvider";
 import styled from "styled-components";
 
 interface ContainerProps {

--- a/app/components/ViewManager/index.tsx
+++ b/app/components/ViewManager/index.tsx
@@ -1,13 +1,13 @@
-import ActionSheetViewManager from "components/ViewManager/ActionSheetViewManager";
-import CoverFlowViewManager from "components/ViewManager/CoverFlowViewManager";
-import FullScreenViewManager from "components/ViewManager/FullScreenViewManager";
-import KeyboardViewManager from "components/ViewManager/KeyboardViewManager";
-import PopupViewManager from "components/ViewManager/PopupViewManager";
-import SplitScreenViewManager from "components/ViewManager/SplitScreenViewManager";
-import viewConfigMap, { ViewConfig } from "components/views";
-import { useEventListener, useViewContext } from "hooks";
+import ActionSheetViewManager from "@/components/ViewManager/ActionSheetViewManager";
+import CoverFlowViewManager from "@/components/ViewManager/CoverFlowViewManager";
+import FullScreenViewManager from "@/components/ViewManager/FullScreenViewManager";
+import KeyboardViewManager from "@/components/ViewManager/KeyboardViewManager";
+import PopupViewManager from "@/components/ViewManager/PopupViewManager";
+import SplitScreenViewManager from "@/components/ViewManager/SplitScreenViewManager";
+import viewConfigMap, { ViewConfig } from "@/components/views";
+import { useEventListener, useViewContext } from "@/hooks";
 import styled from "styled-components";
-import { IpodEvent } from "utils/events";
+import { IpodEvent } from "@/utils/events";
 
 /** Prevents the user from scrolling the display with a mouse. */
 const Mask = styled.div`

--- a/app/components/previews/GamesPreview.tsx
+++ b/app/components/previews/GamesPreview.tsx
@@ -1,7 +1,7 @@
 import { motion } from "framer-motion";
 import styled from "styled-components";
-import { Unit } from "utils/constants";
-import { APP_URL } from "utils/constants/api";
+import { Unit } from "@/utils/constants";
+import { APP_URL } from "@/utils/constants/api";
 
 const Container = styled(motion.div)`
   display: flex;

--- a/app/components/previews/MusicPreview.tsx
+++ b/app/components/previews/MusicPreview.tsx
@@ -1,12 +1,12 @@
 import { useMemo } from "react";
 
-import { AuthPrompt, KenBurns, LoadingScreen } from "components";
+import { AuthPrompt, KenBurns, LoadingScreen } from "@/components";
 import { motion } from "framer-motion";
-import { useSettings } from "hooks";
+import { useSettings } from "@/hooks";
 import styled from "styled-components";
-import { useFetchAlbums } from "hooks/utils/useDataFetcher";
-import { previewSlideRight } from "animation";
-import { getArtwork } from "utils";
+import { useFetchAlbums } from "@/hooks/utils/useDataFetcher";
+import { previewSlideRight } from "@/animation";
+import { getArtwork } from "@/utils";
 
 const Container = styled(motion.div)`
   z-index: 1;

--- a/app/components/previews/NowPlayingPreview.tsx
+++ b/app/components/previews/NowPlayingPreview.tsx
@@ -1,7 +1,7 @@
 import { motion } from "framer-motion";
-import { useAudioPlayer } from "hooks";
+import { useAudioPlayer } from "@/hooks";
 import styled from "styled-components";
-import * as Utils from "utils";
+import * as Utils from "@/utils";
 
 const Container = styled(motion.div)`
   height: 100%;

--- a/app/components/previews/ServicePreview.tsx
+++ b/app/components/previews/ServicePreview.tsx
@@ -1,8 +1,8 @@
 import { motion } from "framer-motion";
-import { useSettings } from "hooks";
+import { useSettings } from "@/hooks";
 import styled from "styled-components";
-import { Unit } from "utils/constants";
-import { APP_URL } from "utils/constants/api";
+import { Unit } from "@/utils/constants";
+import { APP_URL } from "@/utils/constants/api";
 
 const Container = styled(motion.div)`
   display: flex;

--- a/app/components/previews/SettingsPreview.tsx
+++ b/app/components/previews/SettingsPreview.tsx
@@ -1,7 +1,7 @@
 import { motion } from "framer-motion";
 import styled from "styled-components";
-import { Unit } from "utils/constants";
-import { APP_URL } from "utils/constants/api";
+import { Unit } from "@/utils/constants";
+import { APP_URL } from "@/utils/constants/api";
 
 const Container = styled(motion.div)`
   display: flex;

--- a/app/components/previews/ThemePreview.tsx
+++ b/app/components/previews/ThemePreview.tsx
@@ -1,6 +1,6 @@
 import { motion } from "framer-motion";
 import styled from "styled-components";
-import { APP_URL } from "utils/constants/api";
+import { APP_URL } from "@/utils/constants/api";
 
 const Container = styled(motion.div)`
   display: flex;

--- a/app/components/views/AboutView/index.tsx
+++ b/app/components/views/AboutView/index.tsx
@@ -1,9 +1,9 @@
-import { SelectableList, SelectableListOption } from "components";
-import { viewConfigMap } from "components/views";
-import { useMenuHideView, useScrollHandler } from "hooks";
+import { SelectableList, SelectableListOption } from "@/components";
+import { viewConfigMap } from "@/components/views";
+import { useMenuHideView, useScrollHandler } from "@/hooks";
 import styled from "styled-components";
-import { Unit } from "utils/constants";
-import { APP_URL } from "utils/constants/api";
+import { Unit } from "@/utils/constants";
+import { APP_URL } from "@/utils/constants/api";
 
 const Container = styled.div`
   display: flex;

--- a/app/components/views/AlbumView/index.tsx
+++ b/app/components/views/AlbumView/index.tsx
@@ -1,10 +1,10 @@
 import { useMemo } from "react";
 
-import { SelectableList, SelectableListOption } from "components";
-import { viewConfigMap } from "components/views";
-import { useMenuHideView, useScrollHandler } from "hooks";
-import * as Utils from "utils";
-import { useFetchAlbum } from "hooks/utils/useDataFetcher";
+import { SelectableList, SelectableListOption } from "@/components";
+import { viewConfigMap } from "@/components/views";
+import { useMenuHideView, useScrollHandler } from "@/hooks";
+import * as Utils from "@/utils";
+import { useFetchAlbum } from "@/hooks/utils/useDataFetcher";
 
 interface Props {
   id: string;

--- a/app/components/views/AlbumsView/index.tsx
+++ b/app/components/views/AlbumsView/index.tsx
@@ -1,11 +1,11 @@
 import { useMemo } from "react";
 
-import { AuthPrompt, SelectableList, SelectableListOption } from "components";
-import { useMenuHideView, useScrollHandler, useSettings } from "hooks";
-import * as Utils from "utils";
+import { AuthPrompt, SelectableList, SelectableListOption } from "@/components";
+import { useMenuHideView, useScrollHandler, useSettings } from "@/hooks";
+import * as Utils from "@/utils";
 
 import viewConfigMap, { AlbumView } from "..";
-import { useFetchAlbums } from "hooks/utils/useDataFetcher";
+import { useFetchAlbums } from "@/hooks/utils/useDataFetcher";
 
 interface Props {
   albums?: MediaApi.Album[];

--- a/app/components/views/ArtistView/index.tsx
+++ b/app/components/views/ArtistView/index.tsx
@@ -1,10 +1,10 @@
 import { useMemo } from "react";
 
-import { SelectableList, SelectableListOption } from "components";
-import { AlbumView, viewConfigMap } from "components/views";
-import { useMenuHideView, useScrollHandler } from "hooks";
-import * as Utils from "utils";
-import { useFetchArtistAlbums } from "hooks/utils/useDataFetcher";
+import { SelectableList, SelectableListOption } from "@/components";
+import { AlbumView, viewConfigMap } from "@/components/views";
+import { useMenuHideView, useScrollHandler } from "@/hooks";
+import * as Utils from "@/utils";
+import { useFetchArtistAlbums } from "@/hooks/utils/useDataFetcher";
 
 interface Props {
   id: string;

--- a/app/components/views/ArtistsView/index.tsx
+++ b/app/components/views/ArtistsView/index.tsx
@@ -1,11 +1,11 @@
 import { useMemo } from "react";
 
-import { AuthPrompt, SelectableList, SelectableListOption } from "components";
-import { useMenuHideView, useScrollHandler, useSettings } from "hooks";
-import * as Utils from "utils";
+import { AuthPrompt, SelectableList, SelectableListOption } from "@/components";
+import { useMenuHideView, useScrollHandler, useSettings } from "@/hooks";
+import * as Utils from "@/utils";
 
 import viewConfigMap, { ArtistView } from "..";
-import { useFetchArtists } from "hooks/utils/useDataFetcher";
+import { useFetchArtists } from "@/hooks/utils/useDataFetcher";
 
 interface Props {
   artists?: MediaApi.Artist[];

--- a/app/components/views/BrickGameView/index.tsx
+++ b/app/components/views/BrickGameView/index.tsx
@@ -1,6 +1,6 @@
 import { useEffect } from "react";
 
-import { useMenuHideView } from "hooks";
+import { useMenuHideView } from "@/hooks";
 import styled from "styled-components";
 
 import viewConfigMap from "..";

--- a/app/components/views/CoverFlowView/AlbumCover.tsx
+++ b/app/components/views/CoverFlowView/AlbumCover.tsx
@@ -1,7 +1,7 @@
-import { fadeScale } from "animation";
+import { fadeScale } from "@/animation";
 import { AnimatePresence, motion } from "framer-motion";
 import styled, { css } from "styled-components";
-import * as Utils from "utils";
+import * as Utils from "@/utils";
 
 import BacksideContent from "./BacksideContent";
 import { Point } from "./CoverFlow";

--- a/app/components/views/CoverFlowView/BacksideContent.tsx
+++ b/app/components/views/CoverFlowView/BacksideContent.tsx
@@ -4,13 +4,13 @@ import {
   LoadingScreen,
   SelectableList,
   SelectableListOption,
-} from "components";
-import { useEventListener, useScrollHandler, useViewContext } from "hooks";
+} from "@/components";
+import { useEventListener, useScrollHandler, useViewContext } from "@/hooks";
 import styled from "styled-components";
 
 import viewConfigMap from "..";
-import { IpodEvent } from "utils/events";
-import { useFetchAlbum } from "hooks/utils/useDataFetcher";
+import { IpodEvent } from "@/utils/events";
+import { useFetchAlbum } from "@/hooks/utils/useDataFetcher";
 
 const Container = styled.div`
   position: absolute;

--- a/app/components/views/CoverFlowView/CoverFlow.tsx
+++ b/app/components/views/CoverFlowView/CoverFlow.tsx
@@ -1,13 +1,13 @@
 import { useCallback, useEffect, useRef, useState } from "react";
 
-import { fade } from "animation";
-import { NowPlaying } from "components";
+import { fade } from "@/animation";
+import { NowPlaying } from "@/components";
 import { AnimatePresence, motion } from "framer-motion";
-import { useEventListener, useViewContext } from "hooks";
+import { useEventListener, useViewContext } from "@/hooks";
 import styled from "styled-components";
 
 import AlbumCover from "./AlbumCover";
-import { IpodEvent } from "utils/events";
+import { IpodEvent } from "@/utils/events";
 
 export type Point = {
   x: number;

--- a/app/components/views/CoverFlowView/index.tsx
+++ b/app/components/views/CoverFlowView/index.tsx
@@ -1,12 +1,12 @@
 import React, { useCallback } from "react";
 
-import { AuthPrompt, LoadingScreen } from "components";
-import { useEventListener, useSettings, useViewContext } from "hooks";
+import { AuthPrompt, LoadingScreen } from "@/components";
+import { useEventListener, useSettings, useViewContext } from "@/hooks";
 import styled from "styled-components";
 
 import CoverFlow from "./CoverFlow";
-import { IpodEvent } from "utils/events";
-import { useFetchAlbums } from "hooks/utils/useDataFetcher";
+import { IpodEvent } from "@/utils/events";
+import { useFetchAlbums } from "@/hooks/utils/useDataFetcher";
 
 const Container = styled.div`
   height: 100%;

--- a/app/components/views/GamesView/index.tsx
+++ b/app/components/views/GamesView/index.tsx
@@ -1,7 +1,7 @@
-import { SelectableList, SelectableListOption } from "components";
-import { SplitScreenPreview } from "components/previews";
-import { BrickGameView, viewConfigMap } from "components/views";
-import { useMenuHideView, useScrollHandler } from "hooks";
+import { SelectableList, SelectableListOption } from "@/components";
+import { SplitScreenPreview } from "@/components/previews";
+import { BrickGameView, viewConfigMap } from "@/components/views";
+import { useMenuHideView, useScrollHandler } from "@/hooks";
 
 const GamesView = () => {
   useMenuHideView(viewConfigMap.games.id);

--- a/app/components/views/HomeView/index.tsx
+++ b/app/components/views/HomeView/index.tsx
@@ -4,8 +4,8 @@ import {
   getConditionalOption,
   SelectableList,
   SelectableListOption,
-} from "components";
-import { SplitScreenPreview } from "components/previews";
+} from "@/components";
+import { SplitScreenPreview } from "@/components/previews";
 import {
   CoverFlowView,
   GamesView,
@@ -13,7 +13,7 @@ import {
   NowPlayingView,
   SettingsView,
   viewConfigMap,
-} from "components/views";
+} from "@/components/views";
 import {
   useAudioPlayer,
   useEventListener,
@@ -22,8 +22,8 @@ import {
   useSettings,
   useSpotifySDK,
   useViewContext,
-} from "hooks";
-import { IpodEvent } from "utils/events";
+} from "@/hooks";
+import { IpodEvent } from "@/utils/events";
 
 const strings = {
   nowPlaying: "Now Playing",

--- a/app/components/views/MusicView/index.tsx
+++ b/app/components/views/MusicView/index.tsx
@@ -1,7 +1,7 @@
 import React, { useMemo } from "react";
 
-import { SelectableList, SelectableListOption } from "components";
-import { SplitScreenPreview } from "components/previews";
+import { SelectableList, SelectableListOption } from "@/components";
+import { SplitScreenPreview } from "@/components/previews";
 import {
   AlbumsView,
   ArtistsView,
@@ -10,13 +10,13 @@ import {
   PlaylistsView,
   SearchView,
   viewConfigMap,
-} from "components/views";
+} from "@/components/views";
 import {
   useAudioPlayer,
   useMenuHideView,
   useScrollHandler,
   useSettings,
-} from "hooks";
+} from "@/hooks";
 
 const MusicView = () => {
   const { isAppleAuthorized } = useSettings();

--- a/app/components/views/NowPlayingView/index.tsx
+++ b/app/components/views/NowPlayingView/index.tsx
@@ -1,6 +1,6 @@
-import { NowPlaying } from "components";
-import viewConfigMap from "components/views";
-import { useMenuHideView, useViewContext } from "hooks";
+import { NowPlaying } from "@/components";
+import viewConfigMap from "@/components/views";
+import { useMenuHideView, useViewContext } from "@/hooks";
 
 const NowPlayingView = () => {
   useMenuHideView(viewConfigMap.nowPlaying.id);

--- a/app/components/views/PlaylistView/index.tsx
+++ b/app/components/views/PlaylistView/index.tsx
@@ -1,10 +1,10 @@
 import { useMemo } from "react";
 
-import { SelectableList, SelectableListOption } from "components";
-import { viewConfigMap } from "components/views";
-import { useMenuHideView, useScrollHandler } from "hooks";
-import * as Utils from "utils";
-import { useFetchPlaylist } from "hooks/utils/useDataFetcher";
+import { SelectableList, SelectableListOption } from "@/components";
+import { viewConfigMap } from "@/components/views";
+import { useMenuHideView, useScrollHandler } from "@/hooks";
+import * as Utils from "@/utils";
+import { useFetchPlaylist } from "@/hooks/utils/useDataFetcher";
 
 interface Props {
   id: string;

--- a/app/components/views/PlaylistsView/index.tsx
+++ b/app/components/views/PlaylistsView/index.tsx
@@ -1,11 +1,11 @@
 import { useMemo } from "react";
 
-import { AuthPrompt, SelectableList, SelectableListOption } from "components";
-import { useMenuHideView, useScrollHandler, useSettings } from "hooks";
-import * as Utils from "utils";
+import { AuthPrompt, SelectableList, SelectableListOption } from "@/components";
+import { useMenuHideView, useScrollHandler, useSettings } from "@/hooks";
+import * as Utils from "@/utils";
 
 import viewConfigMap, { PlaylistView } from "..";
-import { useFetchPlaylists } from "hooks/utils/useDataFetcher";
+import { useFetchPlaylists } from "@/hooks/utils/useDataFetcher";
 
 interface Props {
   playlists?: MediaApi.Playlist[];

--- a/app/components/views/SearchView/index.tsx
+++ b/app/components/views/SearchView/index.tsx
@@ -8,18 +8,18 @@ import {
   PlaylistsView,
   SelectableList,
   SelectableListOption,
-} from "components";
-import { SongsView, viewConfigMap } from "components/views";
+} from "@/components";
+import { SongsView, viewConfigMap } from "@/components/views";
 import {
   useEffectOnce,
   useKeyboardInput,
   useMenuHideView,
   useScrollHandler,
   useSettings,
-} from "hooks";
-import { useFetchSearchResults } from "hooks/utils/useDataFetcher";
-import { APP_URL } from "utils/constants/api";
-import { pluralize } from "utils/strings";
+} from "@/hooks";
+import { useFetchSearchResults } from "@/hooks/utils/useDataFetcher";
+import { APP_URL } from "@/utils/constants/api";
+import { pluralize } from "@/utils/strings";
 
 const SearchView = () => {
   useMenuHideView(viewConfigMap.search.id);

--- a/app/components/views/SettingsView/index.tsx
+++ b/app/components/views/SettingsView/index.tsx
@@ -4,16 +4,16 @@ import {
   getConditionalOption,
   SelectableList,
   SelectableListOption,
-} from "components";
-import { SplitScreenPreview } from "components/previews";
-import viewConfigMap, { AboutView } from "components/views";
+} from "@/components";
+import { SplitScreenPreview } from "@/components/previews";
+import viewConfigMap, { AboutView } from "@/components/views";
 import {
   useMenuHideView,
   useMusicKit,
   useScrollHandler,
   useSettings,
   useSpotifySDK,
-} from "hooks";
+} from "@/hooks";
 
 const SettingsView = () => {
   useMenuHideView(viewConfigMap.settings.id);

--- a/app/components/views/SongsView/index.tsx
+++ b/app/components/views/SongsView/index.tsx
@@ -1,9 +1,9 @@
 import { useMemo } from "react";
 
-import { SelectableList, SelectableListOption } from "components";
-import { viewConfigMap } from "components/views";
-import { useMenuHideView, useScrollHandler } from "hooks";
-import * as Utils from "utils";
+import { SelectableList, SelectableListOption } from "@/components";
+import { viewConfigMap } from "@/components/views";
+import { useMenuHideView, useScrollHandler } from "@/hooks";
+import * as Utils from "@/utils";
 
 interface Props {
   songs: MediaApi.Song[];

--- a/app/components/views/index.ts
+++ b/app/components/views/index.ts
@@ -1,4 +1,4 @@
-import { SplitScreenPreview } from "components/previews";
+import { SplitScreenPreview } from "@/components/previews";
 
 export { default as AboutView } from "./AboutView";
 export { default as AlbumView } from "./AlbumView";

--- a/app/hooks/audio/useAudioPlayer.tsx
+++ b/app/hooks/audio/useAudioPlayer.tsx
@@ -6,11 +6,11 @@ import {
   useState,
 } from "react";
 
-import { useEventListener, useMKEventListener } from "hooks";
-import * as ConversionUtils from "utils/conversion";
+import { useEventListener, useMKEventListener } from "@/hooks";
+import * as ConversionUtils from "@/utils/conversion";
 
 import { useMusicKit, useSettings, useSpotifySDK, VOLUME_KEY } from "..";
-import { IpodEvent } from "utils/events";
+import { IpodEvent } from "@/utils/events";
 
 const defaultPlatbackInfoState = {
   isPlaying: false,

--- a/app/hooks/musicKit/useMKDataFetcher.ts
+++ b/app/hooks/musicKit/useMKDataFetcher.ts
@@ -1,8 +1,8 @@
 import { useCallback } from "react";
 
-import { useMusicKit } from "hooks";
+import { useMusicKit } from "@/hooks";
 import queryString from "query-string";
-import * as ConversionUtils from "utils/conversion";
+import * as ConversionUtils from "@/utils/conversion";
 
 /**
  *  Accepts information about the current API request  as well as

--- a/app/hooks/musicKit/useMusicKit.tsx
+++ b/app/hooks/musicKit/useMusicKit.tsx
@@ -1,7 +1,7 @@
 import { createContext, useCallback, useContext } from "react";
 
-import { useSettings, useViewContext } from "hooks";
-import views from "components/views";
+import { useSettings, useViewContext } from "@/hooks";
+import views from "@/components/views";
 
 export interface MusicKitState {
   musicKit?: typeof MusicKit;

--- a/app/hooks/navigation/useKeyboardInput.tsx
+++ b/app/hooks/navigation/useKeyboardInput.tsx
@@ -1,8 +1,8 @@
 import { useCallback, useState } from "react";
 
-import { viewConfigMap } from "components";
-import { useViewContext } from "hooks";
-import { useEventListener } from "hooks/utils";
+import { viewConfigMap } from "@/components";
+import { useViewContext } from "@/hooks";
+import { useEventListener } from "@/hooks/utils";
 
 interface KeyboardInputHook {
   value: string;

--- a/app/hooks/navigation/useMenuHideView.ts
+++ b/app/hooks/navigation/useMenuHideView.ts
@@ -1,8 +1,8 @@
 import { useCallback } from "react";
 
-import { useEventListener, useViewContext } from "hooks";
+import { useEventListener, useViewContext } from "@/hooks";
 
-import { IpodEvent } from "utils/events";
+import { IpodEvent } from "@/utils/events";
 
 /**
  * A quick way to use the menu button as a back button.

--- a/app/hooks/navigation/useScrollHandler.tsx
+++ b/app/hooks/navigation/useScrollHandler.tsx
@@ -4,17 +4,17 @@ import {
   ActionSheetOptionProps,
   PopupOptionProps,
   SelectableListOption,
-} from "components";
-import viewConfigMap, { NowPlayingView } from "components/views";
-import useHapticFeedback from "hooks/useHapticFeedback";
-import { IpodEvent } from "utils/events";
+} from "@/components";
+import viewConfigMap, { NowPlayingView } from "@/components/views";
+import useHapticFeedback from "@/hooks/useHapticFeedback";
+import { IpodEvent } from "@/utils/events";
 
 import {
   useAudioPlayer,
   useEffectOnce,
   useEventListener,
   useViewContext,
-} from "hooks";
+} from "@/hooks";
 
 /** Gets the initial index for the scroll position. If there is a selected option,
  * this will initialize our initial scroll position at the selectedOption  */

--- a/app/hooks/navigation/useViewContext.ts
+++ b/app/hooks/navigation/useViewContext.ts
@@ -4,9 +4,9 @@ import {
   ScreenViewOptionProps,
   ViewContext,
   ViewOptions,
-} from "providers/ViewContextProvider";
-import { SplitScreenPreview } from "components";
-import views from "components/views";
+} from "@/providers/ViewContextProvider";
+import { SplitScreenPreview } from "@/components";
+import views from "@/components/views";
 
 export interface ViewContextHook {
   /** Push an instance of ViewOptions to the viewStack. */

--- a/app/hooks/spotify/useSpotifyDataFetcher.ts
+++ b/app/hooks/spotify/useSpotifyDataFetcher.ts
@@ -1,7 +1,7 @@
 import { useCallback } from "react";
 
-import { useSpotifySDK } from "hooks";
-import * as ConversionUtils from "utils/conversion";
+import { useSpotifySDK } from "@/hooks";
+import * as ConversionUtils from "@/utils/conversion";
 import querystring from "query-string";
 
 /**

--- a/app/hooks/spotify/useSpotifySDK.tsx
+++ b/app/hooks/spotify/useSpotifySDK.tsx
@@ -1,15 +1,15 @@
 import { useCallback, useContext, useEffect, useRef } from "react";
 
-import { useViewContext } from "hooks";
-import * as SpotifyUtils from "utils/spotify";
+import { useViewContext } from "@/hooks";
+import * as SpotifyUtils from "@/utils/spotify";
 
 import { useSettings } from "..";
-import { API_URL } from "utils/constants/api";
+import { API_URL } from "@/utils/constants/api";
 import {
   SpotifySDKContext,
   SpotifySDKState,
-} from "providers/SpotifySdkProvider";
-import views from "components/views";
+} from "@/providers/SpotifySdkProvider";
+import views from "@/components/views";
 
 export type SpotifySDKHook = SpotifySDKState & {
   signIn: () => void;

--- a/app/hooks/utils/useDataFetcher.ts
+++ b/app/hooks/utils/useDataFetcher.ts
@@ -5,7 +5,7 @@ import {
   useMusicKit,
   useSettings,
   useSpotifyDataFetcher,
-} from "hooks";
+} from "@/hooks";
 
 interface UserLibraryProps {
   inLibrary?: boolean;

--- a/app/hooks/utils/useSettings.tsx
+++ b/app/hooks/utils/useSettings.tsx
@@ -5,9 +5,9 @@ import {
   useEffect,
   useState,
 } from "react";
-import { ColorScheme } from "utils/colorScheme";
-import { SELECTED_SERVICE_KEY } from "utils/service";
-import { DeviceThemeName } from "utils/themes";
+import { ColorScheme } from "@/utils/colorScheme";
+import { SELECTED_SERVICE_KEY } from "@/utils/service";
+import { DeviceThemeName } from "@/utils/themes";
 
 type StreamingService = "apple" | "spotify";
 

--- a/app/layout.tsx
+++ b/app/layout.tsx
@@ -1,5 +1,5 @@
-import { getRootAppUrl } from "api/spotify/utils";
-import StyledComponentsRegistry from "lib/registry";
+import { getRootAppUrl } from "@/api/spotify/utils";
+import StyledComponentsRegistry from "@/lib/registry";
 import { Metadata, Viewport } from "next";
 import Script from "next/script";
 

--- a/app/page.tsx
+++ b/app/page.tsx
@@ -1,5 +1,5 @@
-import { Ipod } from "components/Ipod";
-import { APPLE_DEVELOPER_TOKEN } from "./utils/constants/api";
+import { Ipod } from "@/components/Ipod";
+import { APPLE_DEVELOPER_TOKEN } from "@/utils/constants/api";
 
 export default async function Page({
   searchParams,

--- a/app/providers/MusicKitProvider.tsx
+++ b/app/providers/MusicKitProvider.tsx
@@ -3,7 +3,7 @@ import {
   useEventListener,
   useMKEventListener,
   MusicKitContext,
-} from "hooks";
+} from "@/hooks";
 import { useRef, useState, useCallback, useEffect } from "react";
 
 export interface MusicKitProviderProps {

--- a/app/providers/SpotifySdkProvider.tsx
+++ b/app/providers/SpotifySdkProvider.tsx
@@ -1,9 +1,9 @@
 import { getCookie, setCookie } from "cookies-next";
-import { useViewContext, useSettings, useInterval, useEffectOnce } from "hooks";
+import { useViewContext, useSettings, useInterval, useEffectOnce } from "@/hooks";
 import { useState, useRef, useCallback, useEffect, createContext } from "react";
-import * as SpotifyUtils from "utils/spotify";
-import { SPOTIFY_TOKENS_COOKIE_NAME } from "utils/constants/api";
-import views from "components/views";
+import * as SpotifyUtils from "@/utils/spotify";
+import { SPOTIFY_TOKENS_COOKIE_NAME } from "@/utils/constants/api";
+import views from "@/components/views";
 
 export interface SpotifySDKState {
 	isPlayerConnected: boolean;

--- a/app/providers/ViewContextProvider.tsx
+++ b/app/providers/ViewContextProvider.tsx
@@ -1,8 +1,8 @@
 import { createContext, useState } from "react";
 
-import { SelectableListOption } from "components/SelectableList";
-import views, { HomeView, ViewConfig } from "components/views";
-import { SplitScreenPreview } from "components/previews";
+import { SelectableListOption } from "@/components/SelectableList";
+import views, { HomeView, ViewConfig } from "@/components/views";
+import { SplitScreenPreview } from "@/components/previews";
 
 type SharedOptionProps = {
   id: ViewConfig["id"];

--- a/app/utils/constants/Theme.ts
+++ b/app/utils/constants/Theme.ts
@@ -1,4 +1,4 @@
-import { APP_URL } from "utils/constants/api";
+import { APP_URL } from "@/utils/constants/api";
 
 export type DeviceTheme = {
   body: {

--- a/app/utils/events.ts
+++ b/app/utils/events.ts
@@ -1,4 +1,4 @@
-import { ScrollDirection } from "components/ClickWheel/sharedTypes";
+import { ScrollDirection } from "@/components/ClickWheel/sharedTypes";
 
 /** The click-wheel control associated with the particular event */
 type BaseEventContext =

--- a/app/utils/index.ts
+++ b/app/utils/index.ts
@@ -1,5 +1,5 @@
-import { SelectableListOption } from "components/SelectableList";
-import { DEFAULT_ARTWORK_URL } from "utils/constants/api";
+import { SelectableListOption } from "@/components/SelectableList";
+import { DEFAULT_ARTWORK_URL } from "@/utils/constants/api";
 
 /** Accepts a url with '{w}' and '{h}' and replaces them with the specified size */
 export const getArtwork = (size: number | string, url?: string) => {

--- a/app/utils/spotify.ts
+++ b/app/utils/spotify.ts
@@ -1,6 +1,6 @@
-import { getRootAppUrl } from "utils";
-import { API_URL } from "utils/constants/api";
-import { SELECTED_SERVICE_KEY } from "utils/service";
+import { getRootAppUrl } from "@/utils";
+import { API_URL } from "@/utils/constants/api";
+import { SELECTED_SERVICE_KEY } from "@/utils/service";
 
 export type TokenResponse = {
   accessToken?: string;

--- a/app/utils/themes.ts
+++ b/app/utils/themes.ts
@@ -1,6 +1,6 @@
-import { DEVICE_COLOR_KEY } from "hooks";
+import { DEVICE_COLOR_KEY } from "@/hooks";
 
-import * as Theme from "utils/constants/Theme";
+import * as Theme from "@/utils/constants/Theme";
 
 const supportedThemes = {
   silver: "silver",

--- a/tsconfig.json
+++ b/tsconfig.json
@@ -1,6 +1,5 @@
 {
   "compilerOptions": {
-    "baseUrl": "./app",
     "target": "ES2020",
     "lib": [
       "dom",


### PR DESCRIPTION
This pull migrates all imports to use the `@/` path alias for consistency and better clarity.

- Removes `baseUrl` from `tsconfig.json` 
- Updates all imports across the codebase to use `@/` prefix
- Covers components, hooks, utils, providers, types, lib, styles, api, and animation imports
- Prevents potential conflicts with npm package names
- Follows Next.js conventions and modern best practices