### PR TITLE
Improve Spotify & Apple Music integrations

### DIFF
--- a/app/components/Controls/TrackProgress.tsx
+++ b/app/components/Controls/TrackProgress.tsx
@@ -12,7 +12,15 @@ const Container = styled.div`
   flex: 1;
   height: 1em;
   padding: 0 ${Unit.SM};
-  -webkit-box-reflect: below 0px -webkit-gradient(linear, left top, left bottom, from(transparent), color-stop(60%, transparent), to(rgba(250, 250, 250, 0.1)));
+  -webkit-box-reflect: below
+    0px -webkit-gradient(
+      linear,
+      left top,
+      left bottom,
+      from(transparent),
+      color-stop(60%, transparent),
+      to(rgba(250, 250, 250, 0.1))
+    );
   display: grid;
   grid-template-columns: 40px 1fr 40px;
 `;
@@ -39,12 +47,12 @@ const TrackProgress = () => {
     timeRemaining,
   } = playbackInfo;
 
-  /** Update the progress bar every second. */
-  useInterval(() => {
-    if (isPlaying && !isPaused) {
-      updatePlaybackInfo();
-    }
-  }, 1000);
+  /** Update the progress bar every second when playing. */
+  useInterval(
+    updatePlaybackInfo,
+    1000,
+    !(isPlaying && !isPaused) // Skip when not playing or paused
+  );
 
   const hasNowPlayingItem = !!nowPlayingItem;
 

--- a/app/components/Controls/index.tsx
+++ b/app/components/Controls/index.tsx
@@ -42,7 +42,8 @@ const ScrubberContainer = styled.div<ContainerProps>`
 `;
 
 const Controls = () => {
-  const { volume, active, setEnabled } = useVolumeHandler();
+  const { volume, active, setEnabled, increaseVolume, decreaseVolume } =
+    useVolumeHandler();
   const [isScrubbing, setIsScrubbing] = useState(false);
 
   const handleCenterClick = useCallback(() => {
@@ -57,14 +58,28 @@ const Controls = () => {
     }
   }, [isScrubbing, setEnabled]);
 
+  const handleForwardScroll = useCallback(() => {
+    if (!isScrubbing) {
+      increaseVolume();
+    }
+  }, [isScrubbing, increaseVolume]);
+
+  const handleBackwardScroll = useCallback(() => {
+    if (!isScrubbing) {
+      decreaseVolume();
+    }
+  }, [isScrubbing, decreaseVolume]);
+
   useEventListener<IpodEvent>("centerclick", handleCenterClick);
+  useEventListener<IpodEvent>("forwardscroll", handleForwardScroll);
+  useEventListener<IpodEvent>("backwardscroll", handleBackwardScroll);
 
   return (
     <Container>
-      <MainContainer $isHidden={isScrubbing}>
-        {active && !isScrubbing && <VolumeBar percent={volume * 100} />}
-      </MainContainer>
-      <MainContainer $isHidden={isScrubbing}>
+      <ScrubberContainer $isHidden={isScrubbing || !active}>
+        <VolumeBar percent={volume * 100} />
+      </ScrubberContainer>
+      <MainContainer $isHidden={isScrubbing || active}>
         <TrackProgress />
       </MainContainer>
       <ScrubberContainer $isHidden={!isScrubbing}>

--- a/app/hooks/spotify/useSpotifySDK.tsx
+++ b/app/hooks/spotify/useSpotifySDK.tsx
@@ -31,6 +31,10 @@ export const useSpotifySDK = ({
   const { showPopup } = useViewContext();
   const state = useContext(SpotifySDKContext);
 
+  if (!state) {
+    throw new Error("useSpotifySDK must be used within SpotifySDKProvider");
+  }
+
   const authorizationChangedRef = useRef(onAuthorizationChanged);
 
   useEffect(() => {
@@ -71,7 +75,7 @@ export const useSpotifySDK = ({
   }, [isSpotifyAuthorized, setService, showPopup, state.isPlayerConnected]);
 
   const signOut = useCallback(async () => {
-    state.spotifyPlayer.disconnect();
+    state.spotifyPlayer?.disconnect();
     setIsSpotifyAuthorized(false);
 
     await SpotifyUtils.logOutSpotify();

--- a/app/types/MusicKit.V3.extensions.d.ts
+++ b/app/types/MusicKit.V3.extensions.d.ts
@@ -1,0 +1,26 @@
+/**
+ * MusicKit V3 Type Extensions
+ *
+ * This file extends the existing @types/musickit-js definitions
+ * to include properties and methods available in MusicKit JS V3
+ * that are not yet present in the official type definitions.
+ */
+
+declare namespace MusicKit {
+  interface MusicKitInstance {
+    // Playback state properties
+    isPlaying: boolean;
+
+    // Current playback information
+    currentPlaybackTime: number;
+    currentPlaybackTimeRemaining: number;
+    currentPlaybackProgress: number;
+    currentPlaybackDuration: number;
+
+    // Current item
+    nowPlayingItem: MusicKit.MediaItem | null;
+
+    // Volume control
+    volume: number;
+  }
+}

--- a/app/types/index.d.ts
+++ b/app/types/index.d.ts
@@ -9,4 +9,5 @@
 /// <reference path="MusicKit.Player.d.ts" />
 /// <reference path="MusicKit.Queue.d.ts" />
 /// <reference path="MusicKit.SetQueueOptions.d.ts" />
+/// <reference path="MusicKit.V3.extensions.d.ts" />
 /// <reference path="Media.API.d.ts" />

--- a/package.json
+++ b/package.json
@@ -28,7 +28,7 @@
     "@next/bundle-analyzer": "^14.0.4",
     "@types/cookie": "^0.5.1",
     "@types/he": "^1.1.2",
-    "@types/musickit-js": "^1.0.8",
+    "@types/musickit-js": "^1.0.10",
     "@types/node": "^20.18.0",
     "@types/react": "^18.3.12",
     "@types/react-dom": "^18.3.1",

--- a/yarn.lock
+++ b/yarn.lock
@@ -224,10 +224,10 @@
   resolved "https://registry.yarnpkg.com/@types/json5/-/json5-0.0.29.tgz#ee28707ae94e11d2b827bcbe5270bcea7f3e71ee"
   integrity sha512-dRLjCWHYg4oaA77cxO64oO+7JwCwnIzkZPdrrC71jQmQtlhM556pwKo5bUzqvZndkVbeFLIIi+9TC40JNF5hNQ==
 
-"@types/musickit-js@^1.0.8":
-  version "1.0.8"
-  resolved "https://registry.yarnpkg.com/@types/musickit-js/-/musickit-js-1.0.8.tgz#cc430616b897f9edd68dc9b62dcf63012b1aac39"
-  integrity sha512-n9Nb9NKBjVB2mKGCch8TXuzJRyWX6il8zKkO1RsvdeqI5uwLL5KteL/Ki1mwmlACZkKA8euAk84onjIqdWcHCQ==
+"@types/musickit-js@^1.0.10":
+  version "1.0.10"
+  resolved "https://registry.yarnpkg.com/@types/musickit-js/-/musickit-js-1.0.10.tgz#6cfb096e6541ea0cb4b604218f0ed0a1596d1302"
+  integrity sha512-puBKnswvciuRuGxqN9NGUb7jKJUVHCpEKpKrWlgwRduI1I/Y0pC0HOgOLGaeB22xwL2h3rGsKU+qI+YsjMtbug==
 
 "@types/node@^16.10.2":
   version "16.18.70"


### PR DESCRIPTION
This pull fixes quite a few bugs in the audio player, improves type safety, and re-adds proper volume scroll control to the now playing screen.

- Adds MusicKit V3 type extensions and removes 14+ `as any` casts
- Fixes missing `await` statements causing race conditions
- Fixes division by zero in Spotify progress calculation
- Fixes incorrect seekToTime implementation (music.seekToTime vs music.player.seekToTime)
- Fixes Spotify playback state logic
- Fixes scrubber race condition causing brief time reset when seeking
- Adds volume control via scroll wheel on now playing screen
- Adds proper error handling to Spotify API fetch
- Replaces polling with reactive updates for better performance
- Updates @types/musickit-js from v1.0.8 to v1.0.10