### PR TITLE
Add shuffle and repeat controls

### DIFF
--- a/app/components/Header/index.tsx
+++ b/app/components/Header/index.tsx
@@ -5,7 +5,6 @@ import styled from "styled-components";
 import { APP_URL } from "@/utils/constants/api";
 
 const Container = styled.div`
-  width: 100%;
   display: flex;
   justify-content: space-between;
   align-items: center;
@@ -13,7 +12,7 @@ const Container = styled.div`
   height: 20px;
   background: linear-gradient(180deg, #feffff 0%, #b1b6b9 100%);
   border-bottom: 1px solid #7995a3;
-  box-sizing: border-box;
+  min-width: 0;
 `;
 
 const Text = styled.h3`
@@ -22,6 +21,8 @@ const Text = styled.h3`
   overflow: hidden;
   white-space: nowrap;
   text-overflow: ellipsis;
+  min-width: 0;
+  flex: 1;
 `;
 
 const IconContainer = styled.div`

--- a/app/components/NowPlaying/index.tsx
+++ b/app/components/NowPlaying/index.tsx
@@ -49,10 +49,10 @@ const ArtworkContainer = styled.div<ArtworkContainerProps>`
       left bottom,
       from(transparent),
       color-stop(70%, transparent),
-      to(rgba(250, 250, 250, 0.1))
+      to(rgba(240, 240, 240, 0.2))
     );
   transform-style: preserve-3d;
-  transform: rotateY(18deg);
+  transform: rotateY(35deg);
   opacity: ${(props) => (props.$isHidden ? 0 : 1)};
 `;
 

--- a/app/components/NowPlaying/index.tsx
+++ b/app/components/NowPlaying/index.tsx
@@ -31,6 +31,7 @@ const MetadataContainer = styled.div`
   display: flex;
   height: 70%;
   padding: 0 ${Unit.XS};
+  perspective: 1000px;
 `;
 
 interface ArtworkContainerProps {
@@ -51,30 +52,36 @@ const ArtworkContainer = styled.div<ArtworkContainerProps>`
       to(rgba(250, 250, 250, 0.1))
     );
   transform-style: preserve-3d;
-  perspective: 500px;
-  opacity: ${(props) => props.$isHidden && 0};
+  transform: rotateY(18deg);
+  opacity: ${(props) => (props.$isHidden ? 0 : 1)};
 `;
 
 const Artwork = styled.img`
   height: 100%;
   width: 100%;
-  transform: rotateY(18deg);
   border: 1px solid #f3f3f3;
 `;
 
 const InfoContainer = styled.div`
   flex: 1;
   margin: auto 0 auto clamp(0.5rem, 5vw, 0.5rem);
+  min-width: 0;
 `;
 
-const Text = styled.h3`
+const Text = styled.div`
   margin: 0;
   font-size: 0.92rem;
+  font-weight: 600;
 `;
 
 const Subtext = styled(Text)`
   color: rgb(99, 101, 103);
   font-size: 0.75rem;
+  display: -webkit-box;
+  -webkit-line-clamp: 2;
+  -webkit-box-orient: vertical;
+  overflow: hidden;
+  text-overflow: ellipsis;
 `;
 
 const ControlsContainer = styled.div`
@@ -125,7 +132,14 @@ const NowPlaying = ({ hideArtwork, onHide }: Props) => {
       </StatusBar>
       <MetadataContainer>
         <ArtworkContainer $isHidden={hideArtwork}>
-          <Artwork src={artworkUrl} />
+          <Artwork
+            src={artworkUrl}
+            alt={
+              nowPlayingItem?.name
+                ? `${nowPlayingItem.name} album artwork`
+                : "Album artwork"
+            }
+          />
         </ArtworkContainer>
         <InfoContainer>
           <Text>{nowPlayingItem?.name}</Text>

--- a/app/components/NowPlaying/index.tsx
+++ b/app/components/NowPlaying/index.tsx
@@ -11,6 +11,22 @@ const Container = styled.div`
   overflow: hidden;
 `;
 
+const StatusBar = styled.div`
+  position: absolute;
+  top: 0;
+  width: 100%;
+  display: flex;
+  justify-content: flex-end;
+  gap: ${Unit.XS};
+  padding: ${Unit.XS} ${Unit.SM} 0;
+  height: 1.5em;
+`;
+
+const StatusEmoji = styled.span`
+  font-size: 14px;
+  opacity: 0.8;
+`;
+
 const MetadataContainer = styled.div`
   display: flex;
   height: 70%;
@@ -25,7 +41,15 @@ const ArtworkContainer = styled.div<ArtworkContainerProps>`
   height: 8em;
   width: 8em;
   margin: auto ${Unit.SM};
-  -webkit-box-reflect: below 0px -webkit-gradient(linear, left top, left bottom, from(transparent), color-stop(70%, transparent), to(rgba(250, 250, 250, 0.1)));
+  -webkit-box-reflect: below
+    0px -webkit-gradient(
+      linear,
+      left top,
+      left bottom,
+      from(transparent),
+      color-stop(70%, transparent),
+      to(rgba(250, 250, 250, 0.1))
+    );
   transform-style: preserve-3d;
   perspective: 500px;
   opacity: ${(props) => props.$isHidden && 0};
@@ -65,8 +89,13 @@ interface Props {
 }
 
 const NowPlaying = ({ hideArtwork, onHide }: Props) => {
-  const { nowPlayingItem, updateNowPlayingItem, updatePlaybackInfo } =
-    useAudioPlayer();
+  const {
+    nowPlayingItem,
+    updateNowPlayingItem,
+    updatePlaybackInfo,
+    shuffleMode,
+    repeatMode,
+  } = useAudioPlayer();
 
   const handlePlaybackChange = useCallback(
     ({ state }: { state: MusicKit.PlaybackStates }) => {
@@ -89,6 +118,11 @@ const NowPlaying = ({ hideArtwork, onHide }: Props) => {
 
   return (
     <Container>
+      <StatusBar>
+        {shuffleMode !== "off" && <StatusEmoji>🔀</StatusEmoji>}
+        {repeatMode === "one" && <StatusEmoji>🔂</StatusEmoji>}
+        {repeatMode === "all" && <StatusEmoji>🔁</StatusEmoji>}
+      </StatusBar>
       <MetadataContainer>
         <ArtworkContainer $isHidden={hideArtwork}>
           <Artwork src={artworkUrl} />

--- a/app/components/SelectableList/SelectableListItem.tsx
+++ b/app/components/SelectableList/SelectableListItem.tsx
@@ -3,6 +3,8 @@ import { Unit } from "@/utils/constants";
 
 import { SelectableListOption } from ".";
 import { APP_URL } from "@/utils/constants/api";
+import { useAudioPlayer } from "@/hooks";
+import { useMemo } from "react";
 
 const LabelContainer = styled.div`
   flex: 1;
@@ -54,8 +56,10 @@ const Image = styled.img`
   margin-right: ${Unit.XXS};
 `;
 
-const Icon = styled.img`
+const Icon = styled.img<{ $size?: number }>`
   margin-left: auto;
+  width: ${({ $size }) => ($size ? `${$size}px` : "auto")};
+  height: ${({ $size }) => ($size ? `${$size}px` : "auto")};
 `;
 
 interface Props {
@@ -64,6 +68,30 @@ interface Props {
 }
 
 const SelectableListItem = ({ option, isActive }: Props) => {
+  const { nowPlayingItem, playbackInfo } = useAudioPlayer();
+
+  // Check if this specific song is currently playing
+  const isPlayingSong = useMemo(() => {
+    if (option.type !== "song" || !nowPlayingItem) {
+      return false;
+    }
+
+    // Get the specific song for this list item
+    const { queueOptions } = option;
+    const startPosition = queueOptions.startPosition ?? 0;
+
+    const songId =
+      queueOptions.song?.id ??
+      queueOptions.songs?.[startPosition]?.id ??
+      queueOptions.album?.songs[startPosition]?.id ??
+      queueOptions.playlist?.songs[startPosition]?.id;
+
+    return songId === nowPlayingItem.id;
+  }, [option, nowPlayingItem]);
+
+  const isPlaying =
+    isPlayingSong && playbackInfo.isPlaying && !playbackInfo.isPaused;
+
   return (
     <Container $isActive={isActive}>
       {option.imageUrl && <Image alt="List item" src={option.imageUrl} />}
@@ -72,6 +100,13 @@ const SelectableListItem = ({ option, isActive }: Props) => {
         {option.sublabel && <Sublabel>{option.sublabel}</Sublabel>}
       </LabelContainer>
       {isActive && <Icon src={`${APP_URL}/arrow_right.svg`} />}
+      {isPlaying && !isActive && (
+        <Icon
+          src={`${APP_URL}/volume_full.svg`}
+          $size={16}
+          style={{ marginRight: 8 }}
+        />
+      )}
     </Container>
   );
 };

--- a/app/components/SelectableList/SelectableListItem.tsx
+++ b/app/components/SelectableList/SelectableListItem.tsx
@@ -5,6 +5,7 @@ import { SelectableListOption } from ".";
 import { APP_URL } from "@/utils/constants/api";
 import { useAudioPlayer } from "@/hooks";
 import { useMemo } from "react";
+import * as Utils from "@/utils";
 
 const LabelContainer = styled.div`
   flex: 1;
@@ -76,15 +77,10 @@ const SelectableListItem = ({ option, isActive }: Props) => {
       return false;
     }
 
-    // Get the specific song for this list item
-    const { queueOptions } = option;
-    const startPosition = queueOptions.startPosition ?? 0;
-
-    const songId =
-      queueOptions.song?.id ??
-      queueOptions.songs?.[startPosition]?.id ??
-      queueOptions.album?.songs[startPosition]?.id ??
-      queueOptions.playlist?.songs[startPosition]?.id;
+    const songId = Utils.getSongIdFromQueueOptions(
+      option.queueOptions,
+      option.queueOptions.startPosition
+    );
 
     return songId === nowPlayingItem.id;
   }, [option, nowPlayingItem]);

--- a/app/components/ViewManager/CoverFlowViewManager/index.tsx
+++ b/app/components/ViewManager/CoverFlowViewManager/index.tsx
@@ -6,6 +6,8 @@ import styled from "styled-components";
 
 const Container = styled(motion.div)`
   z-index: 0;
+  display: grid;
+  grid-template-rows: 20px 1fr;
   position: absolute;
   width: 100%;
   height: 100%;

--- a/app/components/views/CoverFlowView/BacksideContent.tsx
+++ b/app/components/views/CoverFlowView/BacksideContent.tsx
@@ -14,24 +14,22 @@ const Container = styled.div`
   position: absolute;
   display: flex;
   flex-direction: column;
-  top: -28%;
-  bottom: -50%;
-  left: -50%;
-  right: -50%;
-  border: 1px solid lightgray;
+  inset: -28% -50% -38%;
+  border: 1px solid #d3d3d3;
   background: white;
   transform: rotateY(180deg);
 `;
 
 const InfoContainer = styled.div`
+  flex-shrink: 0;
   padding: 4px 8px;
-  background: linear-gradient(180deg, #6585ad 0%, #789ab3 100%);
+  background: linear-gradient(to bottom, #6585ad, #789ab3);
   border-bottom: 1px solid #6d87a3;
 `;
 
 const Text = styled.h3`
-  font-size: 16px;
   margin: 0;
+  font-size: 16px;
   color: white;
 `;
 
@@ -40,7 +38,6 @@ const Subtext = styled(Text)`
 `;
 
 const ListContainer = styled.div`
-  position: relative;
   flex: 1;
   overflow: auto;
 `;

--- a/app/components/views/CoverFlowView/BacksideContent.tsx
+++ b/app/components/views/CoverFlowView/BacksideContent.tsx
@@ -25,16 +25,24 @@ const InfoContainer = styled.div`
   padding: 4px 8px;
   background: linear-gradient(to bottom, #6585ad, #789ab3);
   border-bottom: 1px solid #6d87a3;
+  min-width: 0;
 `;
 
 const Text = styled.h3`
   margin: 0;
   font-size: 16px;
   color: white;
+  display: -webkit-box;
+  -webkit-line-clamp: 2;
+  -webkit-box-orient: vertical;
+  overflow: hidden;
+  text-overflow: ellipsis;
+  word-break: break-word;
 `;
 
 const Subtext = styled(Text)`
   font-size: 14px;
+  -webkit-line-clamp: 1;
 `;
 
 const ListContainer = styled.div`

--- a/app/components/views/CoverFlowView/CoverFlow.tsx
+++ b/app/components/views/CoverFlowView/CoverFlow.tsx
@@ -19,49 +19,41 @@ const Container = styled.div`
 `;
 
 const AlbumsContainer = styled.div`
-  height: 100%;
-  z-index: 2;
   position: relative;
+  z-index: 2;
   display: flex;
   flex-wrap: nowrap;
-  flex: 1;
+  height: 100%;
   padding-top: 20px;
-  -webkit-overflow-scrolling: touch; /* [3] */
-  -ms-overflow-style: -ms-autohiding-scrollbar;
   perspective: 500px;
 `;
 
 const InfoContainer = styled(motion.div)`
-  z-index: 0;
   position: absolute;
-  bottom: 0;
-  left: 0;
-  right: 0;
+  inset: auto 0 0;
+  z-index: 0;
+  display: -webkit-box;
   height: 24%;
   text-align: center;
-  display: -webkit-box;
+  overflow: hidden;
   -webkit-line-clamp: 3;
   -webkit-box-orient: vertical;
-  overflow: hidden;
 `;
 
 const NowPlayingContainer = styled(motion.div)`
-  z-index: 1;
   position: absolute;
-  top: 20px;
-  bottom: 0;
-  left: 0;
-  right: 0;
+  inset: 20px 0 0;
+  z-index: 1;
 `;
 
 const Text = styled.h3`
   margin: 0;
+  padding: 0 16px;
   font-size: 16px;
   text-align: center;
-  padding: 0 16px;
 
-  :first-of-type {
-    margin-top: 24px;
+  &:first-of-type {
+    margin-top: 8px;
   }
 `;
 

--- a/app/components/views/CoverFlowView/CoverFlow.tsx
+++ b/app/components/views/CoverFlowView/CoverFlow.tsx
@@ -32,12 +32,10 @@ const InfoContainer = styled(motion.div)`
   position: absolute;
   inset: auto 0 0;
   z-index: 0;
-  display: -webkit-box;
-  height: 24%;
+  padding-bottom: 16px;
   text-align: center;
   overflow: hidden;
-  -webkit-line-clamp: 3;
-  -webkit-box-orient: vertical;
+  min-width: 0;
 `;
 
 const NowPlayingContainer = styled(motion.div)`
@@ -46,11 +44,21 @@ const NowPlayingContainer = styled(motion.div)`
   z-index: 1;
 `;
 
-const Text = styled.h3`
+interface TextProps {
+  $clamp?: number;
+}
+
+const Text = styled.h3<TextProps>`
   margin: 0;
   padding: 0 16px;
   font-size: 16px;
   text-align: center;
+  display: -webkit-box;
+  -webkit-line-clamp: ${(props) => props.$clamp ?? 1};
+  -webkit-box-orient: vertical;
+  overflow: hidden;
+  text-overflow: ellipsis;
+  word-break: break-word;
 
   &:first-of-type {
     margin-top: 8px;
@@ -134,8 +142,8 @@ const CoverFlow = ({ albums }: Props) => {
       <AnimatePresence>
         {albums.length && !playingAlbum && (
           <InfoContainer {...fade}>
-            <Text>{albums[activeIndex]?.name}</Text>
-            <Text>{albums[activeIndex]?.artistName}</Text>
+            <Text $clamp={1}>{albums[activeIndex]?.name}</Text>
+            <Text $clamp={1}>{albums[activeIndex]?.artistName}</Text>
           </InfoContainer>
         )}
         {playingAlbum && (

--- a/app/components/views/SettingsView/index.tsx
+++ b/app/components/views/SettingsView/index.tsx
@@ -6,12 +6,12 @@ import SelectableList, {
 } from "@/components/SelectableList";
 import { SplitScreenPreview } from "@/components/previews";
 import {
+  useAudioPlayer,
   useMenuHideView,
   useMusicKit,
   useScrollHandler,
   useSettings,
   useSpotifySDK,
-  useAudioPlayer,
 } from "@/hooks";
 
 const THEMES = ["silver", "black", "u2"] as const;
@@ -38,7 +38,10 @@ const SettingsView = () => {
     service,
     deviceTheme,
     setDeviceTheme,
+    shuffleMode,
+    repeatMode,
   } = useSettings();
+  const { setShuffleMode, setRepeatMode } = useAudioPlayer();
   const {
     signIn: signInWithApple,
     signOut: signOutApple,
@@ -142,6 +145,60 @@ const SettingsView = () => {
         listOptions: serviceOptions,
         preview: SplitScreenPreview.Service,
       }),
+      /** Add shuffle mode options */
+      ...getConditionalOption(isAuthorized, {
+        type: "actionSheet",
+        id: "shuffle-mode-action-sheet",
+        label: "Shuffle",
+        listOptions: [
+          {
+            type: "action",
+            isSelected: shuffleMode === "off",
+            label: `Off ${shuffleMode === "off" ? "(Current)" : ""}`,
+            onSelect: () => setShuffleMode("off"),
+          },
+          {
+            type: "action",
+            isSelected: shuffleMode === "songs",
+            label: `Songs ${shuffleMode === "songs" ? "(Current)" : ""}`,
+            onSelect: () => setShuffleMode("songs"),
+          },
+          {
+            type: "action",
+            isSelected: shuffleMode === "albums",
+            label: `Albums ${shuffleMode === "albums" ? "(Current)" : ""}`,
+            onSelect: () => setShuffleMode("albums"),
+          },
+        ],
+        preview: SplitScreenPreview.Settings,
+      }),
+      /** Add repeat mode options */
+      ...getConditionalOption(isAuthorized, {
+        type: "actionSheet",
+        id: "repeat-mode-action-sheet",
+        label: "Repeat",
+        listOptions: [
+          {
+            type: "action",
+            isSelected: repeatMode === "off",
+            label: `Off ${repeatMode === "off" ? "(Current)" : ""}`,
+            onSelect: () => setRepeatMode("off"),
+          },
+          {
+            type: "action",
+            isSelected: repeatMode === "one",
+            label: `One ${repeatMode === "one" ? "(Current)" : ""}`,
+            onSelect: () => setRepeatMode("one"),
+          },
+          {
+            type: "action",
+            isSelected: repeatMode === "all",
+            label: `All ${repeatMode === "all" ? "(Current)" : ""}`,
+            onSelect: () => setRepeatMode("all"),
+          },
+        ],
+        preview: SplitScreenPreview.Settings,
+      }),
       {
         type: "actionSheet",
         id: "device-theme-action-sheet",
@@ -166,7 +223,17 @@ const SettingsView = () => {
         preview: SplitScreenPreview.Service,
       }),
     ],
-    [isAuthorized, serviceOptions, themeOptions, signInOptions, signOutOptions]
+    [
+      isAuthorized,
+      serviceOptions,
+      themeOptions,
+      signInOptions,
+      signOutOptions,
+      shuffleMode,
+      setShuffleMode,
+      repeatMode,
+      setRepeatMode,
+    ]
   );
 
   const [scrollIndex] = useScrollHandler("settings", options);

--- a/app/hooks/navigation/useScrollHandler.tsx
+++ b/app/hooks/navigation/useScrollHandler.tsx
@@ -120,10 +120,11 @@ const useScrollHandler = (
         const isSameSong = nowPlayingItem && songId === nowPlayingItem.id;
 
         // If it's the same song, just navigate to Now Playing view
+        // (unless we're in CoverFlow, which handles its own now playing view)
         // Otherwise, play the song
-        if (isSameSong) {
+        if (isSameSong && id !== "coverFlow") {
           showView("nowPlaying");
-        } else {
+        } else if (!isSameSong) {
           await play(option.queueOptions);
 
           if (option.showNowPlayingView) {
@@ -156,15 +157,16 @@ const useScrollHandler = (
         break;
     }
   }, [
-    showActionSheet,
-    showPopup,
-    showView,
+    options,
     index,
     isActive,
-    options,
-    play,
-    nowPlayingItem,
     triggerHaptics,
+    nowPlayingItem,
+    id,
+    showView,
+    showPopup,
+    showActionSheet,
+    play,
   ]);
 
   const handleCenterLongClick = useCallback(async () => {

--- a/app/hooks/utils/useSettings.tsx
+++ b/app/hooks/utils/useSettings.tsx
@@ -10,10 +10,14 @@ import { SELECTED_SERVICE_KEY } from "@/utils/service";
 import { DeviceThemeName } from "@/utils/themes";
 
 type StreamingService = "apple" | "spotify";
+export type ShuffleMode = "off" | "songs" | "albums";
+export type RepeatMode = "off" | "one" | "all";
 
 export const VOLUME_KEY = "ipodVolume";
 export const COLOR_SCHEME_KEY = "ipodColorScheme";
 export const DEVICE_COLOR_KEY = "ipodSelectedDeviceTheme";
+export const SHUFFLE_MODE_KEY = "ipodShuffleMode";
+export const REPEAT_MODE_KEY = "ipodRepeatMode";
 
 export interface SettingsState {
   service?: StreamingService;
@@ -21,6 +25,8 @@ export interface SettingsState {
   isAppleAuthorized: boolean;
   colorScheme: ColorScheme;
   deviceTheme: DeviceThemeName;
+  shuffleMode: ShuffleMode;
+  repeatMode: RepeatMode;
 }
 
 type SettingsContextType = [
@@ -40,6 +46,8 @@ export type SettingsHook = SettingsState & {
   setService: (service?: StreamingService) => void;
   setColorScheme: (colorScheme?: ColorScheme) => void;
   setDeviceTheme: (deviceTheme: DeviceThemeName) => void;
+  setShuffleMode: (mode: ShuffleMode) => void;
+  setRepeatMode: (mode: RepeatMode) => void;
 };
 
 export const useSettings = (): SettingsHook => {
@@ -108,6 +116,22 @@ export const useSettings = (): SettingsHook => {
     [setState]
   );
 
+  const setShuffleMode = useCallback(
+    (mode: ShuffleMode) => {
+      setState((prevState) => ({ ...prevState, shuffleMode: mode }));
+      localStorage.setItem(SHUFFLE_MODE_KEY, mode);
+    },
+    [setState]
+  );
+
+  const setRepeatMode = useCallback(
+    (mode: RepeatMode) => {
+      setState((prevState) => ({ ...prevState, repeatMode: mode }));
+      localStorage.setItem(REPEAT_MODE_KEY, mode);
+    },
+    [setState]
+  );
+
   return {
     ...state,
     isAuthorized: state.isAppleAuthorized || state.isSpotifyAuthorized,
@@ -116,6 +140,8 @@ export const useSettings = (): SettingsHook => {
     setService,
     setColorScheme,
     setDeviceTheme,
+    setShuffleMode,
+    setRepeatMode,
   };
 };
 
@@ -130,6 +156,8 @@ export const SettingsProvider = ({ children }: Props) => {
     service: undefined,
     colorScheme: "default",
     deviceTheme: "silver",
+    shuffleMode: "off",
+    repeatMode: "off",
   });
 
   const handleMount = useCallback(() => {
@@ -142,6 +170,10 @@ export const SettingsProvider = ({ children }: Props) => {
         (localStorage.getItem(COLOR_SCHEME_KEY) as ColorScheme) ?? "default",
       deviceTheme:
         (localStorage.getItem(DEVICE_COLOR_KEY) as DeviceThemeName) ?? "silver",
+      shuffleMode:
+        (localStorage.getItem(SHUFFLE_MODE_KEY) as ShuffleMode) ?? "off",
+      repeatMode:
+        (localStorage.getItem(REPEAT_MODE_KEY) as RepeatMode) ?? "off",
     }));
   }, []);
 

--- a/app/providers/ViewContextProvider.tsx
+++ b/app/providers/ViewContextProvider.tsx
@@ -20,7 +20,9 @@ export type ActionSheetId =
   | "signin-popup"
   | "device-theme-action-sheet"
   | "service-type-action-sheet"
-  | "sign-out-popup";
+  | "sign-out-popup"
+  | "shuffle-mode-action-sheet"
+  | "repeat-mode-action-sheet";
 
 /**
  * Screen view instance - references a view in the registry

--- a/app/types/MusicKit.V3.extensions.d.ts
+++ b/app/types/MusicKit.V3.extensions.d.ts
@@ -22,5 +22,20 @@ declare namespace MusicKit {
 
     // Volume control
     volume: number;
+
+    // Shuffle and repeat modes
+    shuffleMode: PlayerShuffleMode;
+    repeatMode: PlayerRepeatMode;
+  }
+
+  enum PlayerShuffleMode {
+    off = 0,
+    songs = 1,
+  }
+
+  enum PlayerRepeatMode {
+    none = 0,
+    one = 1,
+    all = 2,
   }
 }

--- a/app/utils/index.ts
+++ b/app/utils/index.ts
@@ -65,3 +65,19 @@ export const getRootAppUrl = () => {
 
   return `${protocol}://${rootUrl}`;
 };
+
+/**
+ * Extracts the song ID from queue options.
+ * Handles various queue option formats (song, songs array, album, playlist).
+ */
+export const getSongIdFromQueueOptions = (
+  queueOptions: MediaApi.QueueOptions,
+  startPosition = 0
+): string | undefined => {
+  return (
+    queueOptions.song?.id ??
+    queueOptions.songs?.[startPosition]?.id ??
+    queueOptions.album?.songs[startPosition]?.id ??
+    queueOptions.playlist?.songs[startPosition]?.id
+  );
+};


### PR DESCRIPTION
This pull adds authentic iPod Classic 7th gen shuffle and repeat functionality.

- Adds shuffle mode settings (Off/Songs/Albums) that persist to localStorage
- Adds repeat mode settings (Off/One/All) that persist to localStorage
- Implements shuffle/repeat controls for both Apple Music (MusicKit V3) and Spotify Web API
- Adds shuffle and repeat options to Settings view with action sheets
- Displays status icons (🔀 🔂 🔁) on Now Playing view when active
- Settings apply immediately to current playback (authentic iPod behavior)
- Extends MusicKit V3 types with PlayerShuffleMode and PlayerRepeatMode enums