### PR TITLE
feat: Major visual and UX improvements to Brick game

### DIFF
--- a/app/components/ViewManager/index.tsx
+++ b/app/components/ViewManager/index.tsx
@@ -61,7 +61,19 @@ const ViewManager = () => {
   const popupViews = viewStack.filter(isPopupView);
   const keyboardViews = viewStack.filter(isKeyboardView);
 
-  useEventListener<IpodEvent>("menulongpress", resetViews);
+  // Check if the current view has long press disabled
+  const currentView = viewStack[viewStack.length - 1];
+  const shouldDisableLongPress =
+    currentView?.type === "screen" &&
+    VIEW_REGISTRY[currentView.id as keyof typeof VIEW_REGISTRY]?.disableLongPress;
+
+  const handleMenuLongPress = () => {
+    if (!shouldDisableLongPress) {
+      resetViews();
+    }
+  };
+
+  useEventListener<IpodEvent>("menulongpress", handleMenuLongPress);
 
   return (
     <div>

--- a/app/components/views/BrickGameView/Game.ts
+++ b/app/components/views/BrickGameView/Game.ts
@@ -11,6 +11,10 @@ class App {
   context: CanvasRenderingContext2D | null;
   timeout: number;
   inStasis: boolean;
+  animationFrameId: number | null;
+  canvasWidth: number;
+  canvasHeight: number;
+  private eventListeners: Array<{ event: string; handler: EventListener }>;
 
   constructor() {
     this.initialized = false;
@@ -22,31 +26,43 @@ class App {
     this.context = this.canvas ? this.canvas.getContext("2d") : null;
     this.timeout = 33;
     this.inStasis = false;
+    this.animationFrameId = null;
+    this.canvasWidth = this.canvas?.width ?? 0;
+    this.canvasHeight = this.canvas?.height ?? 0;
+    this.eventListeners = [];
   }
 
   init = () => {
     if (!this.context) {
       console.error("Error getting application context");
-      return; //TODO: notify user
+      return;
     }
 
-    window.addEventListener("centerclick", this.handleCenterClick);
+    const centerClickHandler = this.handleCenterClick;
+    window.addEventListener("centerclick", centerClickHandler);
+    this.eventListeners.push({
+      event: "centerclick",
+      handler: centerClickHandler,
+    });
+
     this.inStasis = false;
 
     if (!this.initialized) {
-      window.addEventListener(
-        "forwardscroll",
-        () => this.player.moveRight(),
-        true
-      );
-      window.addEventListener(
-        "backwardscroll",
-        () => this.player.moveLeft(),
-        true
-      );
-      window.addEventListener("menuclick", () => {
+      const forwardScrollHandler = () => this.player.moveRight();
+      const backwardScrollHandler = () => this.player.moveLeft();
+      const menuClickHandler = () => {
         this.inStasis = true;
-      });
+      };
+
+      window.addEventListener("forwardscroll", forwardScrollHandler, true);
+      window.addEventListener("backwardscroll", backwardScrollHandler, true);
+      window.addEventListener("menuclick", menuClickHandler);
+
+      this.eventListeners.push(
+        { event: "forwardscroll", handler: forwardScrollHandler },
+        { event: "backwardscroll", handler: backwardScrollHandler },
+        { event: "menuclick", handler: menuClickHandler }
+      );
 
       this.setupBricks();
       this.player.draw();
@@ -71,16 +87,15 @@ class App {
 
     this.ball.update();
 
-    requestAnimationFrame(() => {
+    this.animationFrameId = requestAnimationFrame(() => {
       this.update();
     });
   };
 
   clearContext = () => {
     if (this.context && this.canvas) {
-      this.context.clearRect(0, 0, this.canvas.width, this.canvas.height);
+      this.context.clearRect(0, 0, this.canvasWidth, this.canvasHeight);
     }
-    return;
   };
 
   die = () => {
@@ -100,7 +115,6 @@ class App {
     }
   };
 
-  //TODO: this will change per level
   setupBricks = () => {
     this.bricks = [];
 
@@ -132,6 +146,20 @@ class App {
       brick.health = 3;
       this.bricks.push(brick);
     }
+  };
+
+  cleanup = () => {
+    if (this.animationFrameId !== null) {
+      cancelAnimationFrame(this.animationFrameId);
+      this.animationFrameId = null;
+    }
+
+    this.eventListeners.forEach(({ event, handler }) => {
+      window.removeEventListener(event, handler);
+    });
+    this.eventListeners = [];
+
+    this.initialized = false;
   };
 
   reset = () => {
@@ -183,7 +211,7 @@ class Player {
       return;
     }
 
-    if (this.position.x < this.app.canvas.width - this.size.width) {
+    if (this.position.x < this.app.canvasWidth - this.size.width) {
       this.position.x += this.physics.speed * 1.5;
     }
   };
@@ -205,6 +233,7 @@ class Ball {
   size: Dimensions;
   physics: { speed: number };
   direction: Coordinates;
+  readonly radius: number = 10;
 
   constructor(app: App) {
     this.app = app;
@@ -222,11 +251,9 @@ class Ball {
     const context = this.app.context;
     const centerX = this.position.x;
     const centerY = this.position.y;
-    const radius = 10;
 
-    context.fillStyle = "transparent";
     context.beginPath();
-    context.arc(centerX, centerY, radius, 0, 2 * Math.PI, false);
+    context.arc(centerX, centerY, this.radius, 0, 2 * Math.PI, false);
     context.fillStyle = "black";
     context.fill();
     context.lineWidth = 5;
@@ -246,15 +273,10 @@ class Ball {
       return;
     }
 
-    if (this.position.x < 0 || this.position.x > this.app.canvas.width)
-      //Left and Right Bounds
+    if (this.position.x < 0 || this.position.x > this.app.canvasWidth)
       this.direction.x = -this.direction.x;
-    if (this.position.y < 0)
-      //Top Bounds
-      this.direction.y = -this.direction.y;
-    if (this.position.y > this.app.canvas.height)
-      //Bottom Bounds
-      this.app.die(); //TODO: die
+    if (this.position.y < 0) this.direction.y = -this.direction.y;
+    if (this.position.y > this.app.canvasHeight) this.app.die();
 
     if (!this.app.waiting && !this.app.inStasis) {
       this.checkCollisionWithPlayer();
@@ -282,12 +304,24 @@ class Ball {
     if (this.position.x + this.size.width < this.app.player.position.x) return;
 
     // Maps a value from the "in" range to the "out" range. Maybe this should go in a Mathy utils file?
-    const mapValue = (value: number, inMin: number, inMax: number, outMin: number, outMax: number) => {
-      return (value - inMin) * (outMax - outMin) / (inMax - inMin) + outMin;
-    }
+    const mapValue = (
+      value: number,
+      inMin: number,
+      inMax: number,
+      outMin: number,
+      outMax: number
+    ) => {
+      return ((value - inMin) * (outMax - outMin)) / (inMax - inMin) + outMin;
+    };
     // Moving up with a custom angle, based on where the ball is hit
     const hitPosition = this.position.x - this.app.player.position.x;
-    const angle = mapValue(hitPosition, 0, this.app.player.size.width, 0 + 0.5, Math.PI - 0.5);
+    const angle = mapValue(
+      hitPosition,
+      0,
+      this.app.player.size.width,
+      0 + 0.5,
+      Math.PI - 0.5
+    );
     const vx = Math.cos(angle);
     const vy = Math.sin(angle);
     this.direction.x = -vx;
@@ -295,7 +329,7 @@ class Ball {
   };
 
   checkCollisionWithBricks = () => {
-    for (let i = 0; i < this.app.bricks.length; i++) {
+    for (let i = this.app.bricks.length - 1; i >= 0; i--) {
       const brick = this.app.bricks[i];
 
       if (this.position.y + this.size.height < brick.position.y) continue;
@@ -303,33 +337,27 @@ class Ball {
       if (this.position.x > brick.position.x + brick.size.width) continue;
       if (this.position.x + this.size.width < brick.position.x) continue;
 
-      /* If the loop makes it this far, we have a collision */
       brick.health -= 1;
 
       this.app.player.score += 20;
 
       if (brick.health < 1) this.app.bricks.splice(i, 1);
 
-      //Update direction based on where we hit the brick
-
-      //Moving towards lower right
       if (this.direction.x > 0 && this.direction.y > 0) {
-        if (this.position.y > brick.position.y) this.direction.x = -this.direction.x;
+        if (this.position.y > brick.position.y)
+          this.direction.x = -this.direction.x;
         else this.direction.y = -this.direction.y;
-      }
-      //Moving towards lower left
-      else if (this.direction.x < 0 && this.direction.y > 0) {
-        if (this.position.y > brick.position.y) this.direction.x = -this.direction.x;
+      } else if (this.direction.x < 0 && this.direction.y > 0) {
+        if (this.position.y > brick.position.y)
+          this.direction.x = -this.direction.x;
         else this.direction.y = -this.direction.y;
-      }
-      //Moving towards upper right
-      else if (this.direction.x > 0 && this.direction.y < 0) {
-        if (this.position.x > brick.position.x) this.direction.y = -this.direction.y;
+      } else if (this.direction.x > 0 && this.direction.y < 0) {
+        if (this.position.x > brick.position.x)
+          this.direction.y = -this.direction.y;
         else this.direction.x = -this.direction.x;
-      }
-      //Moving towards upper-left
-      else if (this.direction.x < 0 && this.direction.y < 0) {
-        if (this.position.x > brick.position.x + brick.size.width) this.direction.x = -this.direction.x;
+      } else if (this.direction.x < 0 && this.direction.y < 0) {
+        if (this.position.x > brick.position.x + brick.size.width)
+          this.direction.x = -this.direction.x;
         else this.direction.y = -this.direction.y;
       }
     }
@@ -350,32 +378,30 @@ class Brick {
   }
 
   draw = () => {
-    if (!this.app.context) {
+    if (!this.app.context || this.health < 1) {
       return;
     }
 
     switch (this.health) {
       case 3:
-        this.app.context.fillStyle = "rgb(0, 240, 0)"; //Green
+        this.app.context.fillStyle = "rgb(0, 240, 0)";
         break;
       case 2:
-        this.app.context.fillStyle = "rgb(255, 140, 0)"; //Orange
+        this.app.context.fillStyle = "rgb(255, 140, 0)";
         break;
       case 1:
-        this.app.context.fillStyle = "rgb(200, 0, 0)"; //Red
+        this.app.context.fillStyle = "rgb(200, 0, 0)";
         break;
       default:
         break;
     }
 
-    if (this.health > 0) {
-      this.app.context.fillRect(
-        this.position.x,
-        this.position.y,
-        this.size.width - 5,
-        this.size.height - 5
-      );
-    }
+    this.app.context.fillRect(
+      this.position.x,
+      this.position.y,
+      this.size.width - 5,
+      this.size.height - 5
+    );
   };
 }
 

--- a/app/components/views/BrickGameView/Game.ts
+++ b/app/components/views/BrickGameView/Game.ts
@@ -1,5 +1,124 @@
 type Dimensions = { width: number; height: number };
 type Coordinates = { x: number; y: number };
+type BrickColor = "RED" | "ORANGE" | "YELLOW" | "GREEN" | "BLUE";
+
+const BASE_CANVAS = {
+  WIDTH: 340,
+  HEIGHT: 260,
+};
+
+const GAME_CONSTANTS = {
+  PLAYER: {
+    BOTTOM_OFFSET: 3, // Distance from bottom of screen
+    INITIAL_LIVES: 3,
+    WIDTH: 70,
+    HEIGHT: 8,
+    SPEED: 3,
+    SPEED_MULTIPLIER: 1,
+    FRICTION: 0.85,
+    VELOCITY_STOP_THRESHOLD: 0.1,
+  },
+  BALL: {
+    LEFT_OFFSET: 8, // Distance from left edge
+    RADIUS: 6,
+    SPEED: 2,
+    INITIAL_ANGLE: Math.PI / 4,
+    LIGHT_OFFSET: 0.25,
+    LIGHT_INNER_RADIUS: 0.05,
+    GRADIENT_MID_STOP: 0.3,
+  },
+  BRICK: {
+    TOP_MARGIN: 6,
+    SPACING: 3,
+    HEIGHT: 12,
+    ROWS: 5,
+    COLS: 8,
+    COLORS: {
+      RED: {
+        TOP: "rgb(255, 196, 196)",
+        BOTTOM: "rgb(239, 26, 26)",
+        POINTS: 7,
+      },
+      ORANGE: {
+        TOP: "rgb(255, 202, 161)",
+        BOTTOM: "rgb(255, 120, 30)",
+        POINTS: 5,
+      },
+      YELLOW: {
+        TOP: "rgb(254, 242, 189)",
+        BOTTOM: "rgb(240, 195, 31)",
+        POINTS: 3,
+      },
+      GREEN: {
+        TOP: "rgb(167, 255, 209)",
+        BOTTOM: "rgb(23, 200, 112)",
+        POINTS: 1,
+      },
+      BLUE: {
+        TOP: "rgb(140, 200, 255)",
+        BOTTOM: "rgb(0, 100, 222)",
+        POINTS: 1,
+      },
+    },
+  },
+  CANVAS: {
+    BACKGROUND: {
+      TOP: "rgb(64, 162, 247)",
+      BOTTOM: "rgb(141, 204, 254)",
+    },
+    COLORS: {
+      PLAYER: {
+        TOP: "rgb(199, 199, 199)",
+        MIDDLE: "rgb(85, 85, 85)",
+        BOTTOM: "rgb(111, 111, 111)",
+      },
+      BALL: {
+        CENTER: "rgb(171, 171, 171)",
+        MIDDLE: "rgb(98, 98, 98)",
+        EDGE: "rgb(67, 67, 67)",
+      },
+    },
+    SHADOW: {
+      COLOR: "rgba(0, 0, 0, 0.4)",
+      BRICK_COLOR: "rgba(0, 0, 0, 0.3)",
+      BLUR: 4,
+      BRICK_BLUR: 3,
+      OFFSET_Y: 2,
+    },
+    BORDER: {
+      PLAYER_COLOR: "rgba(0, 0, 0, 0.5)",
+      LINE_WIDTH: 1,
+    },
+  },
+  COLLISION: {
+    MIN_BOUNCE_ANGLE: Math.PI / 6,
+    MAX_BOUNCE_ANGLE: (5 * Math.PI) / 6,
+  },
+} as const;
+
+const mapRange = (
+  value: number,
+  inMin: number,
+  inMax: number,
+  outMin: number,
+  outMax: number
+): number => {
+  return ((value - inMin) * (outMax - outMin)) / (inMax - inMin) + outMin;
+};
+
+const checkAABBCollision = (
+  obj1Pos: Coordinates,
+  obj1Size: Dimensions,
+  obj2Pos: Coordinates,
+  obj2Size: Dimensions
+): boolean => {
+  return !(
+    obj1Pos.y + obj1Size.height < obj2Pos.y ||
+    obj1Pos.y > obj2Pos.y + obj2Size.height ||
+    obj1Pos.x > obj2Pos.x + obj2Size.width ||
+    obj1Pos.x + obj1Size.width < obj2Pos.x
+  );
+};
 
 class App {
   initialized: boolean;
@@ -9,26 +128,26 @@ class App {
   bricks: Array<Brick>;
   canvas: HTMLCanvasElement | null;
   context: CanvasRenderingContext2D | null;
-  timeout: number;
   inStasis: boolean;
   animationFrameId: number | null;
   canvasWidth: number;
   canvasHeight: number;
+  scale: number;
   private eventListeners: Array<{ event: string; handler: EventListener }>;
 
-  constructor() {
+  constructor(canvasWidth?: number, canvasHeight?: number) {
     this.initialized = false;
     this.waiting = true;
+    this.canvas = document.querySelector("#brickBreakerCanvas");
+    this.context = this.canvas ? this.canvas.getContext("2d") : null;
+    this.canvasWidth = canvasWidth ?? this.canvas?.width ?? 0;
+    this.canvasHeight = canvasHeight ?? this.canvas?.height ?? 0;
+    this.scale = this.canvasWidth / BASE_CANVAS.WIDTH;
     this.player = new Player(this);
     this.ball = new Ball(this);
     this.bricks = [];
-    this.canvas = document.querySelector("#brickBreakerCanvas");
-    this.context = this.canvas ? this.canvas.getContext("2d") : null;
-    this.timeout = 33;
     this.inStasis = false;
     this.animationFrameId = null;
-    this.canvasWidth = this.canvas?.width ?? 0;
-    this.canvasHeight = this.canvas?.height ?? 0;
     this.eventListeners = [];
   }
 
@@ -37,6 +156,10 @@ class App {
       console.error("Error getting application context");
       return;
     }
+
+    // Enable smooth rendering for better sub-pixel anti-aliasing
+    this.context.imageSmoothingEnabled = true;
+    this.context.imageSmoothingQuality = "high";
 
     const centerClickHandler = this.handleCenterClick;
     window.addEventListener("centerclick", centerClickHandler);
@@ -82,6 +205,7 @@ class App {
 
   update = () => {
     this.clearContext();
+    this.player.update();
     this.player.draw();
     this.drawBricks();
 
@@ -94,13 +218,25 @@ class App {
 
   clearContext = () => {
     if (this.context && this.canvas) {
-      this.context.clearRect(0, 0, this.canvasWidth, this.canvasHeight);
+      const gradient = this.context.createLinearGradient(
+        0,
+        0,
+        0,
+        this.canvasHeight
+      );
+      gradient.addColorStop(0.5, GAME_CONSTANTS.CANVAS.BACKGROUND.TOP);
+      gradient.addColorStop(1, GAME_CONSTANTS.CANVAS.BACKGROUND.BOTTOM);
+      this.context.fillStyle = gradient;
+      this.context.fillRect(0, 0, this.canvasWidth, this.canvasHeight);
     }
   };
 
   die = () => {
-    //TODO: better death!
-    this.player.position.x = 200;
+    this.player.position.x = (this.canvasWidth - this.player.size.width) / 2;
+    this.player.position.y =
+      this.canvasHeight -
+      this.player.size.height -
+      GAME_CONSTANTS.PLAYER.BOTTOM_OFFSET * this.scale;
     this.player.lives -= 1;
 
     if (this.player.lives < 1) this.reset();
@@ -118,34 +254,36 @@ class App {
   setupBricks = () => {
     this.bricks = [];
 
-    const brickTop = 50;
+    const brickConfigs: Array<{ color: BrickColor; rowIndex: number }> = [
+      { color: "RED", rowIndex: 0 },
+      { color: "ORANGE", rowIndex: 1 },
+      { color: "YELLOW", rowIndex: 2 },
+      { color: "GREEN", rowIndex: 3 },
+      { color: "BLUE", rowIndex: 4 },
+    ];
 
-    //Setup back row:
-    for (let i = 0; i < 10; i++) {
-      const brick = new Brick(this);
-      brick.position.x = 100 + i * brick.size.width + i;
-      brick.position.y = brickTop;
-      brick.health = 1;
-      this.bricks.push(brick);
-    }
+    const rightMargin = 4 * this.scale;
+    const leftMargin = 60 * this.scale;
+    const availableWidth = this.canvasWidth - rightMargin - leftMargin;
+    const spacing = GAME_CONSTANTS.BRICK.SPACING * this.scale;
+    const totalSpacing = (GAME_CONSTANTS.BRICK.COLS - 1) * spacing;
+    const brickWidth =
+      (availableWidth - totalSpacing) / GAME_CONSTANTS.BRICK.COLS;
+    const brickHeight = GAME_CONSTANTS.BRICK.HEIGHT * this.scale;
+    const startX = leftMargin;
 
-    //Setup middle row:
-    for (let i = 0; i < 8; i++) {
-      const brick = new Brick(this);
-      brick.position.x = 150 + i * brick.size.width + i;
-      brick.position.y = brickTop + brick.size.height + 1;
-      brick.health = 2;
-      this.bricks.push(brick);
-    }
-
-    //Setup front row:
-    for (let i = 0; i < 6; i++) {
-      const brick = new Brick(this);
-      brick.position.x = 200 + i * brick.size.width + i;
-      brick.position.y = brickTop + 2 * brick.size.height + 1;
-      brick.health = 3;
-      this.bricks.push(brick);
-    }
+    brickConfigs.forEach(({ color, rowIndex }) => {
+      for (let i = 0; i < GAME_CONSTANTS.BRICK.COLS; i++) {
+        const brick = new Brick(this, color);
+        brick.size.width = brickWidth;
+        brick.size.height = brickHeight;
+        brick.position.x = startX + i * (brickWidth + spacing);
+        brick.position.y =
+          GAME_CONSTANTS.BRICK.TOP_MARGIN * this.scale +
+          rowIndex * (brickHeight + spacing);
+        this.bricks.push(brick);
+      }
+    });
   };
 
   cleanup = () => {
@@ -174,16 +312,29 @@ class Player {
   position: Coordinates;
   score: number;
   lives: number;
-  physics: { speed: number };
+  physics: { speed: number; velocity: number; friction: number };
   size: Dimensions;
 
   constructor(app: App) {
     this.app = app;
-    this.position = { x: 200, y: 480 };
+    this.size = {
+      height: GAME_CONSTANTS.PLAYER.HEIGHT * app.scale,
+      width: GAME_CONSTANTS.PLAYER.WIDTH * app.scale,
+    };
+    this.position = {
+      x: (app.canvasWidth - this.size.width) / 2, // Center horizontally
+      y:
+        app.canvasHeight -
+        this.size.height -
+        GAME_CONSTANTS.PLAYER.BOTTOM_OFFSET * app.scale,
+    };
     this.score = 0;
-    this.lives = 3;
-    this.physics = { speed: 10 };
-    this.size = { height: 20, width: 150 };
+    this.lives = GAME_CONSTANTS.PLAYER.INITIAL_LIVES;
+    this.physics = {
+      speed: GAME_CONSTANTS.PLAYER.SPEED * app.scale,
+      velocity: 0,
+      friction: GAME_CONSTANTS.PLAYER.FRICTION,
+    };
   }
 
   draw = () => {
@@ -191,8 +342,43 @@ class Player {
       return;
     }
 
-    this.app.context.fillStyle = "black";
-    this.app.context.fillRect(
+    const context = this.app.context;
+
+    // Create vertical linear gradient for paddle
+    const gradient = context.createLinearGradient(
+      this.position.x,
+      this.position.y,
+      this.position.x,
+      this.position.y + this.size.height
+    );
+    gradient.addColorStop(0, GAME_CONSTANTS.CANVAS.COLORS.PLAYER.TOP);
+    gradient.addColorStop(0.5, GAME_CONSTANTS.CANVAS.COLORS.PLAYER.MIDDLE);
+    gradient.addColorStop(1, GAME_CONSTANTS.CANVAS.COLORS.PLAYER.BOTTOM);
+
+    // Add shadow
+    context.shadowColor = GAME_CONSTANTS.CANVAS.SHADOW.COLOR;
+    context.shadowBlur = GAME_CONSTANTS.CANVAS.SHADOW.BLUR * this.app.scale;
+    context.shadowOffsetX = 0;
+    context.shadowOffsetY =
+      GAME_CONSTANTS.CANVAS.SHADOW.OFFSET_Y * this.app.scale;
+
+    context.fillStyle = gradient;
+    context.fillRect(
+      this.position.x,
+      this.position.y,
+      this.size.width,
+      this.size.height
+    );
+
+    // Clear shadow for border
+    context.shadowColor = "transparent";
+    context.shadowBlur = 0;
+
+    // Add border
+    context.strokeStyle = GAME_CONSTANTS.CANVAS.BORDER.PLAYER_COLOR;
+    context.lineWidth =
+      GAME_CONSTANTS.CANVAS.BORDER.LINE_WIDTH * this.app.scale;
+    context.strokeRect(
       this.position.x,
       this.position.y,
       this.size.width,
@@ -200,30 +386,58 @@ class Player {
     );
   };
 
-  moveLeft = () => {
-    if (this.position.x > 0) {
-      this.position.x -= this.physics.speed * 1.5;
+  update = () => {
+    // Apply velocity to position
+    this.position.x += this.physics.velocity;
+
+    // Apply friction to slow down
+    this.physics.velocity *= this.physics.friction;
+
+    // Stop if velocity is very small
+    if (
+      Math.abs(this.physics.velocity) <
+      GAME_CONSTANTS.PLAYER.VELOCITY_STOP_THRESHOLD
+    ) {
+      this.physics.velocity = 0;
     }
+
+    // Clamp position to canvas bounds
+    const maxX = this.app.canvasWidth - this.size.width;
+    this.position.x = Math.max(0, Math.min(maxX, this.position.x));
+  };
+
+  moveLeft = () => {
+    const moveAmount =
+      this.physics.speed * GAME_CONSTANTS.PLAYER.SPEED_MULTIPLIER;
+    this.physics.velocity -= moveAmount;
+
+    // Cap maximum velocity
+    const maxVelocity = this.physics.speed * 3;
+    this.physics.velocity = Math.max(-maxVelocity, this.physics.velocity);
   };
 
   moveRight = () => {
-    if (!this.app.canvas) {
-      return;
-    }
+    const moveAmount =
+      this.physics.speed * GAME_CONSTANTS.PLAYER.SPEED_MULTIPLIER;
+    this.physics.velocity += moveAmount;
 
-    if (this.position.x < this.app.canvasWidth - this.size.width) {
-      this.position.x += this.physics.speed * 1.5;
-    }
+    // Cap maximum velocity
+    const maxVelocity = this.physics.speed * 3;
+    this.physics.velocity = Math.min(maxVelocity, this.physics.velocity);
   };
 
   reset = () => {
-    this.lives = 3;
+    this.lives = GAME_CONSTANTS.PLAYER.INITIAL_LIVES;
     this.score = 0;
     this.resetPosition();
   };
 
   resetPosition = () => {
-    this.position.x = 200;
+    this.position.x = (this.app.canvasWidth - this.size.width) / 2;
+    this.position.y =
+      this.app.canvasHeight -
+      this.size.height -
+      GAME_CONSTANTS.PLAYER.BOTTOM_OFFSET * this.app.scale;
   };
 }
 
@@ -233,14 +447,24 @@ class Ball {
   size: Dimensions;
   physics: { speed: number };
   direction: Coordinates;
-  readonly radius: number = 10;
+  radius: number;
 
   constructor(app: App) {
     this.app = app;
-    this.position = { x: 0, y: 250 };
-    this.size = { height: 10, width: 10 };
-    this.physics = { speed: 5 };
-    this.direction = { x: Math.cos(Math.PI / 4), y: Math.sin(Math.PI / 4) };
+    this.radius = GAME_CONSTANTS.BALL.RADIUS * app.scale;
+    this.position = {
+      x: GAME_CONSTANTS.BALL.LEFT_OFFSET * app.scale,
+      y: app.canvasHeight / 2, // Center vertically
+    };
+    this.size = {
+      height: this.radius * 2,
+      width: this.radius * 2,
+    };
+    this.physics = { speed: GAME_CONSTANTS.BALL.SPEED * app.scale };
+    this.direction = {
+      x: Math.cos(GAME_CONSTANTS.BALL.INITIAL_ANGLE),
+      y: Math.sin(GAME_CONSTANTS.BALL.INITIAL_ANGLE),
+    };
   }
 
   draw = () => {
@@ -249,23 +473,49 @@ class Ball {
     }
 
     const context = this.app.context;
-    const centerX = this.position.x;
-    const centerY = this.position.y;
+
+    // Use sub-pixel positioning for smoother rendering
+    const x = this.position.x;
+    const y = this.position.y;
+
+    // Create radial gradient for ball with subtle light source from top-left
+    const gradient = context.createRadialGradient(
+      x - this.radius * GAME_CONSTANTS.BALL.LIGHT_OFFSET,
+      y - this.radius * GAME_CONSTANTS.BALL.LIGHT_OFFSET,
+      this.radius * GAME_CONSTANTS.BALL.LIGHT_INNER_RADIUS,
+      x,
+      y,
+      this.radius
+    );
+    gradient.addColorStop(0, GAME_CONSTANTS.CANVAS.COLORS.BALL.CENTER);
+    gradient.addColorStop(
+      GAME_CONSTANTS.BALL.GRADIENT_MID_STOP,
+      GAME_CONSTANTS.CANVAS.COLORS.BALL.MIDDLE
+    );
+    gradient.addColorStop(1, GAME_CONSTANTS.CANVAS.COLORS.BALL.EDGE);
+
+    // Add shadow
+    context.shadowColor = GAME_CONSTANTS.CANVAS.SHADOW.COLOR;
+    context.shadowBlur = GAME_CONSTANTS.CANVAS.SHADOW.BLUR * this.app.scale;
+    context.shadowOffsetX = 0;
+    context.shadowOffsetY =
+      GAME_CONSTANTS.CANVAS.SHADOW.OFFSET_Y * this.app.scale;
 
     context.beginPath();
-    context.arc(centerX, centerY, this.radius, 0, 2 * Math.PI, false);
-    context.fillStyle = "black";
+    context.arc(x, y, this.radius, 0, 2 * Math.PI, false);
+    context.fillStyle = gradient;
     context.fill();
-    context.lineWidth = 5;
-    context.strokeStyle = "black";
-    context.stroke();
+
+    // Clear shadow
+    context.shadowColor = "transparent";
+    context.shadowBlur = 0;
   };
 
   reset = () => {
-    this.position.x = 0;
-    this.position.y = 250;
-    this.direction.x = Math.cos(Math.PI / 4);
-    this.direction.y = Math.sin(Math.PI / 4);
+    this.position.x = GAME_CONSTANTS.BALL.LEFT_OFFSET * this.app.scale;
+    this.position.y = this.app.canvasHeight / 2;
+    this.direction.x = Math.cos(GAME_CONSTANTS.BALL.INITIAL_ANGLE);
+    this.direction.y = Math.sin(GAME_CONSTANTS.BALL.INITIAL_ANGLE);
   };
 
   update = () => {
@@ -290,118 +540,134 @@ class Ball {
   };
 
   checkCollisionWithPlayer = () => {
-    if (this.position.y + this.size.height < this.app.player.position.y) return;
     if (
-      this.position.y >
-      this.app.player.position.y + this.app.player.size.height
-    )
+      !checkAABBCollision(
+        this.position,
+        this.size,
+        this.app.player.position,
+        this.app.player.size
+      )
+    ) {
       return;
-    if (
-      this.position.x >
-      this.app.player.position.x + this.app.player.size.width
-    )
-      return;
-    if (this.position.x + this.size.width < this.app.player.position.x) return;
+    }
 
-    // Maps a value from the "in" range to the "out" range. Maybe this should go in a Mathy utils file?
-    const mapValue = (
-      value: number,
-      inMin: number,
-      inMax: number,
-      outMin: number,
-      outMax: number
-    ) => {
-      return ((value - inMin) * (outMax - outMin)) / (inMax - inMin) + outMin;
-    };
-    // Moving up with a custom angle, based on where the ball is hit
     const hitPosition = this.position.x - this.app.player.position.x;
-    const angle = mapValue(
+    const angle = mapRange(
       hitPosition,
       0,
       this.app.player.size.width,
-      0 + 0.5,
-      Math.PI - 0.5
+      GAME_CONSTANTS.COLLISION.MIN_BOUNCE_ANGLE,
+      GAME_CONSTANTS.COLLISION.MAX_BOUNCE_ANGLE
     );
-    const vx = Math.cos(angle);
-    const vy = Math.sin(angle);
-    this.direction.x = -vx;
-    this.direction.y = -vy;
+    this.direction.x = -Math.cos(angle);
+    this.direction.y = -Math.sin(angle);
   };
 
   checkCollisionWithBricks = () => {
     for (let i = this.app.bricks.length - 1; i >= 0; i--) {
       const brick = this.app.bricks[i];
 
-      if (this.position.y + this.size.height < brick.position.y) continue;
-      if (this.position.y > brick.position.y + brick.size.height) continue;
-      if (this.position.x > brick.position.x + brick.size.width) continue;
-      if (this.position.x + this.size.width < brick.position.x) continue;
-
-      brick.health -= 1;
-
-      this.app.player.score += 20;
-
-      if (brick.health < 1) this.app.bricks.splice(i, 1);
-
-      if (this.direction.x > 0 && this.direction.y > 0) {
-        if (this.position.y > brick.position.y)
-          this.direction.x = -this.direction.x;
-        else this.direction.y = -this.direction.y;
-      } else if (this.direction.x < 0 && this.direction.y > 0) {
-        if (this.position.y > brick.position.y)
-          this.direction.x = -this.direction.x;
-        else this.direction.y = -this.direction.y;
-      } else if (this.direction.x > 0 && this.direction.y < 0) {
-        if (this.position.x > brick.position.x)
-          this.direction.y = -this.direction.y;
-        else this.direction.x = -this.direction.x;
-      } else if (this.direction.x < 0 && this.direction.y < 0) {
-        if (this.position.x > brick.position.x + brick.size.width)
-          this.direction.x = -this.direction.x;
-        else this.direction.y = -this.direction.y;
+      if (
+        !checkAABBCollision(
+          this.position,
+          this.size,
+          brick.position,
+          brick.size
+        )
+      ) {
+        continue;
       }
+
+      this.app.player.score += brick.pointValue;
+      this.app.bricks.splice(i, 1);
+
+      this.updateDirectionAfterBrickCollision(brick);
+      break;
+    }
+  };
+
+  private updateDirectionAfterBrickCollision = (brick: Brick) => {
+    if (this.direction.x > 0 && this.direction.y > 0) {
+      if (this.position.y > brick.position.y)
+        this.direction.x = -this.direction.x;
+      else this.direction.y = -this.direction.y;
+    } else if (this.direction.x < 0 && this.direction.y > 0) {
+      if (this.position.y > brick.position.y)
+        this.direction.x = -this.direction.x;
+      else this.direction.y = -this.direction.y;
+    } else if (this.direction.x > 0 && this.direction.y < 0) {
+      if (this.position.x > brick.position.x)
+        this.direction.y = -this.direction.y;
+      else this.direction.x = -this.direction.x;
+    } else if (this.direction.x < 0 && this.direction.y < 0) {
+      if (this.position.x > brick.position.x + brick.size.width)
+        this.direction.x = -this.direction.x;
+      else this.direction.y = -this.direction.y;
     }
   };
 }
 
 class Brick {
   app: App;
-  health: number;
+  color: BrickColor;
+  pointValue: number;
   size: Dimensions;
   position: Coordinates;
 
-  constructor(app: App) {
+  constructor(app: App, color: BrickColor) {
     this.app = app;
-    this.health = 3;
-    this.size = { height: 20, width: 60 };
+    this.color = color;
+    this.pointValue = GAME_CONSTANTS.BRICK.COLORS[color].POINTS;
+    this.size = {
+      height: GAME_CONSTANTS.BRICK.HEIGHT * app.scale,
+      width: 0,
+    };
     this.position = { x: 0, y: 0 };
   }
 
   draw = () => {
-    if (!this.app.context || this.health < 1) {
+    if (!this.app.context) {
       return;
     }
 
-    switch (this.health) {
-      case 3:
-        this.app.context.fillStyle = "rgb(0, 240, 0)";
-        break;
-      case 2:
-        this.app.context.fillStyle = "rgb(255, 140, 0)";
-        break;
-      case 1:
-        this.app.context.fillStyle = "rgb(200, 0, 0)";
-        break;
-      default:
-        break;
-    }
+    const colorConfig = GAME_CONSTANTS.BRICK.COLORS[this.color];
+    const spacing = GAME_CONSTANTS.BRICK.SPACING * this.app.scale;
+    const brickWidth = this.size.width - spacing;
+    const brickHeight = this.size.height - spacing;
 
-    this.app.context.fillRect(
+    const gradient = this.app.context.createLinearGradient(
       this.position.x,
       this.position.y,
-      this.size.width - 5,
-      this.size.height - 5
+      this.position.x,
+      this.position.y + brickHeight
     );
+    gradient.addColorStop(0, colorConfig.TOP);
+    gradient.addColorStop(0.5, colorConfig.BOTTOM);
+
+    this.app.context.shadowColor = GAME_CONSTANTS.CANVAS.SHADOW.BRICK_COLOR;
+    this.app.context.shadowBlur =
+      GAME_CONSTANTS.CANVAS.SHADOW.BRICK_BLUR * this.app.scale;
+    this.app.context.shadowOffsetX = 0;
+    this.app.context.shadowOffsetY =
+      GAME_CONSTANTS.CANVAS.SHADOW.OFFSET_Y * this.app.scale;
+
+    this.app.context.fillStyle = gradient;
+    this.app.context.beginPath();
+    this.app.context.roundRect(
+      this.position.x,
+      this.position.y,
+      brickWidth,
+      brickHeight,
+      0
+    );
+    this.app.context.fill();
+
+    this.app.context.shadowColor = "transparent";
+    this.app.context.shadowBlur = 0;
+
+    this.app.context.strokeStyle = colorConfig.BOTTOM;
+    this.app.context.lineWidth = GAME_CONSTANTS.CANVAS.BORDER.LINE_WIDTH;
+    this.app.context.stroke();
   };
 }
 

--- a/app/components/views/BrickGameView/index.tsx
+++ b/app/components/views/BrickGameView/index.tsx
@@ -1,4 +1,4 @@
-import { useEffect } from "react";
+import { useEffect, useRef } from "react";
 
 import { useMenuHideView } from "@/hooks";
 import styled from "styled-components";
@@ -24,9 +24,17 @@ const Canvas = styled.canvas`
 
 const BrickGame = () => {
   useMenuHideView("brickGame");
+  const gameRef = useRef<Game | null>(null);
+
   useEffect(() => {
     const game = new Game();
     game.init();
+    gameRef.current = game;
+
+    return () => {
+      game.cleanup();
+      gameRef.current = null;
+    };
   }, []);
 
   return (

--- a/app/components/views/BrickGameView/index.tsx
+++ b/app/components/views/BrickGameView/index.tsx
@@ -1,4 +1,4 @@
-import { useEffect, useRef } from "react";
+import { useEffect, useRef, useState } from "react";
 
 import { useMenuHideView } from "@/hooks";
 import styled from "styled-components";
@@ -6,6 +6,7 @@ import styled from "styled-components";
 import Game from "./Game";
 
 const RootContainer = styled.div`
+  width: 100%;
   height: 100%;
   background: rgb(2, 0, 36);
   background: linear-gradient(
@@ -18,16 +19,43 @@ const RootContainer = styled.div`
 `;
 
 const Canvas = styled.canvas`
-  height: 100%;
-  width: 100%;
+  display: block;
+  image-rendering: crisp-edges;
+  object-fit: fill;
 `;
 
 const BrickGame = () => {
   useMenuHideView("brickGame");
   const gameRef = useRef<Game | null>(null);
+  const containerRef = useRef<HTMLDivElement | null>(null);
+  const canvasRef = useRef<HTMLCanvasElement | null>(null);
+  const [dimensions, setDimensions] = useState({ width: 0, height: 0 });
+
+  const dpr = typeof window !== "undefined" ? window.devicePixelRatio || 1 : 1;
 
   useEffect(() => {
-    const game = new Game();
+    if (!containerRef.current) return;
+
+    const width = containerRef.current.clientWidth;
+    const height = containerRef.current.clientHeight;
+    setDimensions({ width, height });
+  }, []);
+
+  useEffect(() => {
+    if (
+      dimensions.width === 0 ||
+      dimensions.height === 0 ||
+      !canvasRef.current
+    ) {
+      return;
+    }
+
+    const context = canvasRef.current.getContext("2d");
+    if (!context) return;
+
+    context.scale(dpr, dpr);
+
+    const game = new Game(dimensions.width, dimensions.height);
     game.init();
     gameRef.current = game;
 
@@ -35,11 +63,20 @@ const BrickGame = () => {
       game.cleanup();
       gameRef.current = null;
     };
-  }, []);
+  }, [dimensions, dpr]);
 
   return (
-    <RootContainer>
-      <Canvas width="800" height="500" id="brickBreakerCanvas">
+    <RootContainer ref={containerRef}>
+      <Canvas
+        ref={canvasRef}
+        id="brickBreakerCanvas"
+        width={dimensions.width * dpr}
+        height={dimensions.height * dpr}
+        style={{
+          width: `${dimensions.width}px`,
+          height: `${dimensions.height}px`,
+        }}
+      >
         <p>Your browser does not support this feature</p>
       </Canvas>
     </RootContainer>

--- a/app/components/views/registry.ts
+++ b/app/components/views/registry.ts
@@ -59,6 +59,7 @@ export type ViewConfig<TViewId extends ViewId = ViewId> = {
   title: string;
   isSplitScreen?: boolean;
   preview?: SplitScreenPreview;
+  disableLongPress?: boolean;
 };
 
 /**
@@ -174,6 +175,7 @@ export const VIEW_REGISTRY = {
     type: "full",
     title: "Brick",
     preview: SplitScreenPreview.Games,
+    disableLongPress: true,
   } as ViewConfig<"brickGame">,
 
   // CoverFlow View


### PR DESCRIPTION
This pull updates the look and feel of Brick to more closely resemble the original game (still no lives or win screen yet)





| Before | After |
|--------|--------|
| <img width="393" height="618" alt="old" src="https://github.com/user-attachments/assets/ebca1ffd-6ee7-4c07-8252-5694c9ff10a1" /> | <img width="389" height="613" alt="now" src="https://github.com/user-attachments/assets/1f707c50-6e93-4835-be5a-126604c82082" /> | 

## Changes

### Visual Enhancements
- Added 3D gradients to ball, paddle, and bricks with top-lit effect
- Implemented drop shadows for depth perception
- Added borders with proper color matching
- Adjusted colors and spacing to match original iPod Classic game

### Performance & Feel  
- Velocity-based paddle movement with friction physics
- Fixed scroll stuttering by accumulating velocity instead of resetting
- Enabled high-quality canvas image smoothing for fluid ball animation
- Proper dynamic canvas sizing with devicePixelRatio support