### PR TITLE
Add haptic feedback support for clicks on iOS

### DIFF
--- a/app/components/views/SettingsView/index.tsx
+++ b/app/components/views/SettingsView/index.tsx
@@ -40,6 +40,8 @@ const SettingsView = () => {
     setDeviceTheme,
     shuffleMode,
     repeatMode,
+    hapticsEnabled,
+    setHapticsEnabled,
   } = useSettings();
   const { setShuffleMode, setRepeatMode } = useAudioPlayer();
   const {
@@ -206,6 +208,26 @@ const SettingsView = () => {
         listOptions: themeOptions,
         preview: SplitScreenPreview.Theme,
       },
+      {
+        type: "actionSheet",
+        id: "haptics-action-sheet",
+        label: "Haptic feedback",
+        listOptions: [
+          {
+            type: "action",
+            isSelected: hapticsEnabled,
+            label: `On ${hapticsEnabled ? "(Current)" : ""}`,
+            onSelect: () => setHapticsEnabled(true),
+          },
+          {
+            type: "action",
+            isSelected: !hapticsEnabled,
+            label: `Off ${!hapticsEnabled ? "(Current)" : ""}`,
+            onSelect: () => setHapticsEnabled(false),
+          },
+        ],
+        preview: SplitScreenPreview.Settings,
+      },
       /** Show the sign in option if not signed into any service. */
       ...getConditionalOption(!isAuthorized, {
         type: "actionSheet",
@@ -233,6 +255,8 @@ const SettingsView = () => {
       setShuffleMode,
       repeatMode,
       setRepeatMode,
+      hapticsEnabled,
+      setHapticsEnabled,
     ]
   );
 

--- a/app/hooks/audio/useAudioPlayer.tsx
+++ b/app/hooks/audio/useAudioPlayer.tsx
@@ -6,7 +6,7 @@ import {
   useState,
 } from "react";
 
-import { useEventListener, useMKEventListener } from "@/hooks";
+import { useEventListener, useMKEventListener, useHapticFeedback } from "@/hooks";
 import * as ConversionUtils from "@/utils/conversion";
 
 import {
@@ -524,9 +524,26 @@ export const AudioPlayerProvider = ({ children }: Props) => {
     ]
   );
 
-  useEventListener<IpodEvent>("playpauseclick", togglePlayPause);
-  useEventListener<IpodEvent>("forwardclick", skipNext);
-  useEventListener<IpodEvent>("backwardclick", skipPrevious);
+  const { triggerHaptics } = useHapticFeedback();
+
+  const handlePlayPauseClick = useCallback(() => {
+    triggerHaptics();
+    togglePlayPause();
+  }, [togglePlayPause, triggerHaptics]);
+
+  const handleSkipNext = useCallback(() => {
+    triggerHaptics();
+    skipNext();
+  }, [skipNext, triggerHaptics]);
+
+  const handleSkipPrevious = useCallback(() => {
+    triggerHaptics();
+    skipPrevious();
+  }, [skipPrevious, triggerHaptics]);
+
+  useEventListener<IpodEvent>("playpauseclick", handlePlayPauseClick);
+  useEventListener<IpodEvent>("forwardclick", handleSkipNext);
+  useEventListener<IpodEvent>("backwardclick", handleSkipPrevious);
 
   // Apple playback event listeners
   useMKEventListener("playbackStateDidChange", handleApplePlaybackStateChange);

--- a/app/hooks/index.ts
+++ b/app/hooks/index.ts
@@ -3,3 +3,4 @@ export * from "./musicKit";
 export * from "./navigation";
 export * from "./spotify";
 export * from "./utils";
+export { default as useHapticFeedback } from "./useHapticFeedback";

--- a/app/hooks/navigation/useLongPressHandler.ts
+++ b/app/hooks/navigation/useLongPressHandler.ts
@@ -1,4 +1,5 @@
 import { useCallback, useRef } from "react";
+import { useHapticFeedback } from "@/hooks";
 
 const LONG_PRESS_THRESHOLD = 500;
 
@@ -15,6 +16,7 @@ export const useLongPressHandler = ({
 }: UseLongPressHandlerProps) => {
   const timeoutRef = useRef<NodeJS.Timeout | null>(null);
   const wasLongPressActivated = useRef(false);
+  const { triggerHaptics } = useHapticFeedback();
 
   const handleClearTimeout = useCallback(() => {
     if (timeoutRef.current) {
@@ -27,9 +29,10 @@ export const useLongPressHandler = ({
   const handlePointerDown = useCallback(() => {
     timeoutRef.current = setTimeout(() => {
       wasLongPressActivated.current = true;
+      triggerHaptics(); // Trigger haptic when long press activates
       onLongPress();
     }, longPressThreshold);
-  }, [longPressThreshold, onLongPress]);
+  }, [longPressThreshold, onLongPress, triggerHaptics]);
 
   const handlePointerUp = useCallback(() => {
     if (wasLongPressActivated.current) {

--- a/app/hooks/navigation/useMenuHideView.ts
+++ b/app/hooks/navigation/useMenuHideView.ts
@@ -1,6 +1,6 @@
 import { useCallback } from "react";
 
-import { useEventListener, useViewContext } from "@/hooks";
+import { useEventListener, useViewContext, useHapticFeedback } from "@/hooks";
 
 import { IpodEvent } from "@/utils/events";
 
@@ -10,12 +10,14 @@ import { IpodEvent } from "@/utils/events";
  */
 const useMenuHideView = (id: string) => {
   const { hideView, viewStack } = useViewContext();
+  const { triggerHaptics } = useHapticFeedback();
 
   const handleClick = useCallback(() => {
     if (viewStack[viewStack.length - 1].id === id) {
+      triggerHaptics();
       hideView();
     }
-  }, [hideView, id, viewStack]);
+  }, [hideView, id, viewStack, triggerHaptics]);
 
   useEventListener<IpodEvent>("menuclick", handleClick);
 };

--- a/app/hooks/navigation/useScrollHandler.tsx
+++ b/app/hooks/navigation/useScrollHandler.tsx
@@ -67,9 +67,12 @@ const useScrollHandler = (
   const debouncedUpdatePreview = useDebouncedCallback(updatePreview, 750);
 
   const handleForwardScroll = useCallback(() => {
+    if (isActive) {
+      triggerHaptics(true);
+    }
+
     setIndex((prevIndex) => {
       if (prevIndex < options.length - 1 && isActive) {
-        triggerHaptics(10);
         debouncedUpdatePreview(prevIndex + 1);
 
         // Trigger near-end-of-list callback when we're halfway through the current list.
@@ -92,9 +95,12 @@ const useScrollHandler = (
   ]);
 
   const handleBackwardScroll = useCallback(() => {
+    if (isActive) {
+      triggerHaptics(true);
+    }
+
     setIndex((prevIndex) => {
       if (prevIndex > 0 && isActive) {
-        triggerHaptics(10);
         debouncedUpdatePreview(prevIndex - 1);
         return prevIndex - 1;
       }
@@ -107,7 +113,7 @@ const useScrollHandler = (
   const handleCenterClick = useCallback(async () => {
     const option = options[index];
     if (!isActive || !option) return;
-    triggerHaptics(10);
+    triggerHaptics();
 
     switch (option.type) {
       case "song":

--- a/app/hooks/useHapticFeedback.ts
+++ b/app/hooks/useHapticFeedback.ts
@@ -1,20 +1,64 @@
-import { useCallback, useMemo } from "react";
+import { useCallback, useMemo, useRef } from "react";
+import { haptic } from "ios-haptics";
+import { useSettings } from "@/hooks";
 
-const canUseHaptics = typeof navigator !== "undefined" && "vibrate" in navigator;
+const canUseVibrate =
+  typeof navigator !== "undefined" && "vibrate" in navigator;
 
+/**
+ * Provides haptic feedback for user interactions.
+ *
+ * Uses ios-haptics library for button clicks (iOS 17.4+ Taptic Engine with automatic
+ * fallback to navigator.vibrate() on Android/older iOS).
+ *
+ * For scroll events, directly uses navigator.vibrate() since pan gestures don't trigger
+ * the iOS checkbox-based haptics properly.
+ */
 const useHapticFeedback = () => {
-  const triggerHaptics = useCallback((pattern: number | number[]) => {
-    if (!canUseHaptics) {
-      return;
-    }
-    navigator.vibrate(pattern);
-  }, []);
+  const { hapticsEnabled } = useSettings();
+  const lastTriggerTime = useRef(0);
+  const minInterval = 50; // Minimum 50ms between haptics to prevent rapid-fire calls
 
-  const hooks = useMemo(() => ({
-    triggerHaptics
-  }), [triggerHaptics]);
+  const triggerHaptics = useCallback(
+    (forceVibrate = false) => {
+      // Check if haptics are enabled in settings
+      if (!hapticsEnabled) {
+        return;
+      }
+
+      const now = Date.now();
+
+      // Throttle haptic calls to prevent overlapping vibrations
+      if (now - lastTriggerTime.current < minInterval) {
+        return;
+      }
+
+      lastTriggerTime.current = now;
+
+      if (forceVibrate) {
+        // Use vibrate API directly for scroll events (pan gestures)
+        // iOS checkbox haptics don't work during pan/swipe interactions
+        if (canUseVibrate) {
+          navigator.vibrate(10);
+        }
+        return;
+      }
+
+      // For button clicks: use ios-haptics (Taptic Engine on iOS 17.4+)
+      // Library automatically falls back to navigator.vibrate() on other platforms
+      haptic();
+    },
+    [hapticsEnabled]
+  );
+
+  const hooks = useMemo(
+    () => ({
+      triggerHaptics,
+    }),
+    [triggerHaptics]
+  );
 
   return hooks;
-}
+};
 
 export default useHapticFeedback;

--- a/app/hooks/useHapticFeedback.ts
+++ b/app/hooks/useHapticFeedback.ts
@@ -1,4 +1,4 @@
-import { useCallback, useMemo, useRef } from "react";
+import { useCallback, useMemo } from "react";
 import { haptic } from "ios-haptics";
 import { useSettings } from "@/hooks";
 
@@ -16,8 +16,6 @@ const canUseVibrate =
  */
 const useHapticFeedback = () => {
   const { hapticsEnabled } = useSettings();
-  const lastTriggerTime = useRef(0);
-  const minInterval = 50; // Minimum 50ms between haptics to prevent rapid-fire calls
 
   const triggerHaptics = useCallback(
     (forceVibrate = false) => {
@@ -25,15 +23,6 @@ const useHapticFeedback = () => {
       if (!hapticsEnabled) {
         return;
       }
-
-      const now = Date.now();
-
-      // Throttle haptic calls to prevent overlapping vibrations
-      if (now - lastTriggerTime.current < minInterval) {
-        return;
-      }
-
-      lastTriggerTime.current = now;
 
       if (forceVibrate) {
         // Use vibrate API directly for scroll events (pan gestures)

--- a/app/hooks/utils/useSettings.tsx
+++ b/app/hooks/utils/useSettings.tsx
@@ -18,6 +18,7 @@ export const COLOR_SCHEME_KEY = "ipodColorScheme";
 export const DEVICE_COLOR_KEY = "ipodSelectedDeviceTheme";
 export const SHUFFLE_MODE_KEY = "ipodShuffleMode";
 export const REPEAT_MODE_KEY = "ipodRepeatMode";
+export const HAPTICS_ENABLED_KEY = "ipodHapticsEnabled";
 
 export interface SettingsState {
   service?: StreamingService;
@@ -27,11 +28,12 @@ export interface SettingsState {
   deviceTheme: DeviceThemeName;
   shuffleMode: ShuffleMode;
   repeatMode: RepeatMode;
+  hapticsEnabled: boolean;
 }
 
 type SettingsContextType = [
   SettingsState,
-  React.Dispatch<React.SetStateAction<SettingsState>>
+  React.Dispatch<React.SetStateAction<SettingsState>>,
 ];
 
 export const SettingsContext = createContext<SettingsContextType>([
@@ -48,6 +50,7 @@ export type SettingsHook = SettingsState & {
   setDeviceTheme: (deviceTheme: DeviceThemeName) => void;
   setShuffleMode: (mode: ShuffleMode) => void;
   setRepeatMode: (mode: RepeatMode) => void;
+  setHapticsEnabled: (enabled: boolean) => void;
 };
 
 export const useSettings = (): SettingsHook => {
@@ -103,7 +106,9 @@ export const useSettings = (): SettingsHook => {
     (colorScheme?: ColorScheme) => {
       setState((prevState) => {
         const updatedColorScheme =
-          colorScheme ?? prevState.colorScheme === "dark" ? "default" : "dark";
+          (colorScheme ?? prevState.colorScheme === "dark")
+            ? "default"
+            : "dark";
 
         localStorage.setItem(COLOR_SCHEME_KEY, `${updatedColorScheme}`);
 
@@ -132,6 +137,14 @@ export const useSettings = (): SettingsHook => {
     [setState]
   );
 
+  const setHapticsEnabled = useCallback(
+    (enabled: boolean) => {
+      setState((prevState) => ({ ...prevState, hapticsEnabled: enabled }));
+      localStorage.setItem(HAPTICS_ENABLED_KEY, enabled ? "true" : "false");
+    },
+    [setState]
+  );
+
   return {
     ...state,
     isAuthorized: state.isAppleAuthorized || state.isSpotifyAuthorized,
@@ -142,6 +155,7 @@ export const useSettings = (): SettingsHook => {
     setDeviceTheme,
     setShuffleMode,
     setRepeatMode,
+    setHapticsEnabled,
   };
 };
 
@@ -158,6 +172,7 @@ export const SettingsProvider = ({ children }: Props) => {
     deviceTheme: "silver",
     shuffleMode: "off",
     repeatMode: "off",
+    hapticsEnabled: true,
   });
 
   const handleMount = useCallback(() => {
@@ -174,6 +189,7 @@ export const SettingsProvider = ({ children }: Props) => {
         (localStorage.getItem(SHUFFLE_MODE_KEY) as ShuffleMode) ?? "off",
       repeatMode:
         (localStorage.getItem(REPEAT_MODE_KEY) as RepeatMode) ?? "off",
+      hapticsEnabled: localStorage.getItem(HAPTICS_ENABLED_KEY) !== "false", // Default to true
     }));
   }, []);
 

--- a/app/providers/ViewContextProvider.tsx
+++ b/app/providers/ViewContextProvider.tsx
@@ -22,7 +22,8 @@ export type ActionSheetId =
   | "service-type-action-sheet"
   | "sign-out-popup"
   | "shuffle-mode-action-sheet"
-  | "repeat-mode-action-sheet";
+  | "repeat-mode-action-sheet"
+  | "haptics-action-sheet";
 
 /**
  * Screen view instance - references a view in the registry

--- a/package.json
+++ b/package.json
@@ -16,6 +16,7 @@
     "cookies-next": "^4.1.0",
     "framer-motion": "^11.11.17",
     "he": "^1.2.0",
+    "ios-haptics": "^0.1.4",
     "next": "^14.0.4",
     "query-string": "^7.1.1",
     "react": "^18.2.0",

--- a/yarn.lock
+++ b/yarn.lock
@@ -1863,6 +1863,11 @@ internal-slot@^1.1.0:
     hasown "^2.0.2"
     side-channel "^1.1.0"
 
+ios-haptics@^0.1.4:
+  version "0.1.4"
+  resolved "https://registry.yarnpkg.com/ios-haptics/-/ios-haptics-0.1.4.tgz#6221b3b365eb42a8db3c9804fae9f7d20fe370c7"
+  integrity sha512-94FJcSuvmhe4mHTX4Uauj+/2yhs56m4BLkRScy1vNvkv7H1cSjsvfT+olc1sYOUqWlPhtVttAFBHex0cY9CE7Q==
+
 is-array-buffer@^3.0.1, is-array-buffer@^3.0.2:
   version "3.0.2"
   resolved "https://registry.yarnpkg.com/is-array-buffer/-/is-array-buffer-3.0.2.tgz#f2653ced8412081638ecb0ebbd0c41c6e0aecbbe"


### PR DESCRIPTION
This pull adds haptic feedback to all user interactions on iOS (Android was already supported). Note that scrolling does not trigger haptics on iOS due to limitations of the library being used.

This library ([ios-haptics](https://github.com/tijnjh/ios-haptics)) relies on a hack that utilizes the haptic feedback when checking/uncecking checkbox inputs. On every haptic call, an input is created, checked, and then removed

• Button clicks use `ios-haptics` for Taptic Engine support with automatic fallback
• Scroll events use `navigator.vibrate()` to work during pan gestures (Android only)
• Setting persists to localStorage as `ipodHapticsEnabled`