### PR TITLE
feat: add infinite pagination to albums, artists, and playlists views

### DIFF
--- a/app/components/views/AlbumsView/index.tsx
+++ b/app/components/views/AlbumsView/index.tsx
@@ -1,4 +1,4 @@
-import { useMemo } from "react";
+import { useCallback, useMemo } from "react";
 
 import AuthPrompt from "@/components/AuthPrompt";
 import SelectableList, {
@@ -18,7 +18,12 @@ const AlbumsView = ({ albums, inLibrary = true }: Props) => {
   const { isAuthorized } = useSettings();
   useMenuHideView("albums");
 
-  const { data: fetchedAlbums, isLoading } = useFetchAlbums({
+  const {
+    data: fetchedAlbums,
+    fetchNextPage,
+    isFetchingNextPage,
+    isLoading,
+  } = useFetchAlbums({
     // Don't fetch if we're passed an initial array of albums
     lazy: !!albums,
   });
@@ -40,11 +45,23 @@ const AlbumsView = ({ albums, inLibrary = true }: Props) => {
     );
   }, [albums, fetchedAlbums, inLibrary]);
 
-  const [scrollIndex] = useScrollHandler("albums", options);
+  const handleNearEndOfList = useCallback(() => {
+    if (!isFetchingNextPage) {
+      fetchNextPage();
+    }
+  }, [fetchNextPage, isFetchingNextPage]);
+
+  const [scrollIndex] = useScrollHandler(
+    "albums",
+    options,
+    undefined,
+    handleNearEndOfList
+  );
 
   return isAuthorized ? (
     <SelectableList
       loading={isLoading}
+      loadingNextItems={isFetchingNextPage}
       options={options}
       activeIndex={scrollIndex}
       emptyMessage="No albums"

--- a/app/components/views/ArtistsView/index.tsx
+++ b/app/components/views/ArtistsView/index.tsx
@@ -1,4 +1,4 @@
-import { useMemo } from "react";
+import { useCallback, useMemo } from "react";
 
 import AuthPrompt from "@/components/AuthPrompt";
 import SelectableList, {
@@ -22,7 +22,12 @@ const ArtistsView = ({
 }: Props) => {
   useMenuHideView("artists");
   const { isAuthorized } = useSettings();
-  const { data: fetchedArtists, isLoading: isQueryLoading } = useFetchArtists({
+  const {
+    data: fetchedArtists,
+    fetchNextPage,
+    isFetchingNextPage,
+    isLoading: isQueryLoading,
+  } = useFetchArtists({
     lazy: !!artists,
   });
 
@@ -51,11 +56,23 @@ const ArtistsView = ({
   // cases, we'll check if we have any 'options'
   const isLoading = !options.length && isQueryLoading;
 
-  const [scrollIndex] = useScrollHandler("artists", options);
+  const handleNearEndOfList = useCallback(() => {
+    if (!isFetchingNextPage) {
+      fetchNextPage();
+    }
+  }, [fetchNextPage, isFetchingNextPage]);
+
+  const [scrollIndex] = useScrollHandler(
+    "artists",
+    options,
+    undefined,
+    handleNearEndOfList
+  );
 
   return isAuthorized ? (
     <SelectableList
       loading={isLoading}
+      loadingNextItems={isFetchingNextPage}
       options={options}
       activeIndex={scrollIndex}
       emptyMessage="No saved artists"

--- a/app/components/views/PlaylistsView/index.tsx
+++ b/app/components/views/PlaylistsView/index.tsx
@@ -1,4 +1,4 @@
-import { useMemo } from "react";
+import { useCallback, useMemo } from "react";
 
 import AuthPrompt from "@/components/AuthPrompt";
 import SelectableList, {
@@ -49,7 +49,18 @@ const PlaylistsView = ({ playlists, inLibrary = true }: Props) => {
   // cases, we'll check if we have any 'options'
   const isLoading = !options.length && isQueryLoading;
 
-  const [scrollIndex] = useScrollHandler("playlists", options);
+  const handleNearEndOfList = useCallback(() => {
+    if (!isFetchingNextPage) {
+      fetchNextPage();
+    }
+  }, [fetchNextPage, isFetchingNextPage]);
+
+  const [scrollIndex] = useScrollHandler(
+    "playlists",
+    options,
+    undefined,
+    handleNearEndOfList
+  );
 
   return isAuthorized ? (
     <SelectableList


### PR DESCRIPTION
This pull hooks up pagination to Artists, Albums, and Playlists views. The infrastructure was already there, it just wasn't connected.