### PR TITLE
Use static imports for image assets to enable caching

### DIFF
--- a/app/components/AuthPrompt/index.tsx
+++ b/app/components/AuthPrompt/index.tsx
@@ -3,7 +3,8 @@ import { useState } from "react";
 import { useInterval, useMusicKit } from "@/hooks";
 import styled, { css } from "styled-components";
 import { Unit } from "@/utils/constants";
-import { APP_URL } from "@/utils/constants/api";
+import appleMusicIcon from "@public/apple_music_icon.svg";
+import spotifyIcon from "@public/spotify_icon.svg";
 
 const RootContainer = styled.div`
   display: grid;
@@ -87,13 +88,13 @@ const AuthPrompt = ({ message }: Props) => {
           <StyledImg
             $isHidden={icon === "spotify"}
             alt="app_icon"
-            src={`${APP_URL}/apple_music_icon.svg`}
+            src={appleMusicIcon.src}
           />
         )}
         <StyledImg
           $isHidden={icon === "apple"}
           alt="app_icon"
-          src={`${APP_URL}/spotify_icon.svg`}
+          src={spotifyIcon.src}
         />
       </ImageContainer>
       <Title>{strings.title[icon]}</Title>

--- a/app/components/SelectableList/SelectableListItem.tsx
+++ b/app/components/SelectableList/SelectableListItem.tsx
@@ -98,11 +98,7 @@ const SelectableListItem = ({ option, isActive }: Props) => {
       </LabelContainer>
       {isActive && <Icon src={arrowRight.src} />}
       {isPlaying && !isActive && (
-        <Icon
-          src={volumeFull.src}
-          $size={16}
-          style={{ marginRight: 8 }}
-        />
+        <Icon src={volumeFull.src} $size={16} style={{ marginRight: 8 }} />
       )}
     </Container>
   );

--- a/app/components/SelectableList/SelectableListItem.tsx
+++ b/app/components/SelectableList/SelectableListItem.tsx
@@ -2,10 +2,11 @@ import styled, { css } from "styled-components";
 import { Unit } from "@/utils/constants";
 
 import { SelectableListOption } from ".";
-import { APP_URL } from "@/utils/constants/api";
 import { useAudioPlayer } from "@/hooks";
 import { useMemo } from "react";
 import * as Utils from "@/utils";
+import arrowRight from "@public/arrow_right.svg";
+import volumeFull from "@public/volume_full.svg";
 
 const LabelContainer = styled.div`
   flex: 1;
@@ -95,10 +96,10 @@ const SelectableListItem = ({ option, isActive }: Props) => {
         <Label>{option.label}</Label>
         {option.sublabel && <Sublabel>{option.sublabel}</Sublabel>}
       </LabelContainer>
-      {isActive && <Icon src={`${APP_URL}/arrow_right.svg`} />}
+      {isActive && <Icon src={arrowRight.src} />}
       {isPlaying && !isActive && (
         <Icon
-          src={`${APP_URL}/volume_full.svg`}
+          src={volumeFull.src}
           $size={16}
           style={{ marginRight: 8 }}
         />

--- a/app/components/previews/ServicePreview.tsx
+++ b/app/components/previews/ServicePreview.tsx
@@ -2,7 +2,8 @@ import { motion } from "framer-motion";
 import { useSettings } from "@/hooks";
 import styled from "styled-components";
 import { Unit } from "@/utils/constants";
-import { APP_URL } from "@/utils/constants/api";
+import appleMusicIcon from "@public/apple_music_icon.svg";
+import spotifyIcon from "@public/spotify_icon.svg";
 
 const Container = styled(motion.div)`
   display: flex;
@@ -41,14 +42,13 @@ const strings = {
 const ServicePreview = () => {
   const { service } = useSettings();
 
-  const imgUrl =
-    service === "spotify" ? "spotify_icon.svg" : "apple_music_icon.svg";
+  const imgUrl = service === "spotify" ? spotifyIcon : appleMusicIcon;
 
   const text = strings[service ?? "none"];
 
   return (
     <Container>
-      <Image alt="Service" src={`${APP_URL}/${imgUrl}`} />
+      <Image alt="Service" src={imgUrl.src} />
       <Text>{text}</Text>
       <Subtext>{strings.selected}</Subtext>
     </Container>

--- a/app/utils/constants/Theme.ts
+++ b/app/utils/constants/Theme.ts
@@ -1,4 +1,5 @@
-import { APP_URL } from "@/utils/constants/api";
+import palmSvg from "@public/palm.svg";
+import mneliaSignature from "@public/mnelia_signature.png";
 
 export type DeviceTheme = {
   body: {
@@ -83,7 +84,7 @@ const Mnelia: DeviceTheme = {
     background:
       "linear-gradient(193.42deg, #8676d6 49.48%, rgba(238, 65, 122, 0.74) 100%);",
     sticker1: {
-      background: `url('${APP_URL}/palm.svg') no-repeat bottom left`,
+      background: `url(${palmSvg.src}) no-repeat bottom left`,
       styles: {
         bottom: 0,
         left: 0,
@@ -95,7 +96,7 @@ const Mnelia: DeviceTheme = {
       },
     },
     sticker2: {
-      background: `url('${APP_URL}/palm.svg') no-repeat`,
+      background: `url(${palmSvg.src}) no-repeat`,
       styles: {
         position: "absolute",
         bottom: 0,
@@ -108,7 +109,7 @@ const Mnelia: DeviceTheme = {
       },
     },
     sticker3: {
-      background: `url("${APP_URL}/mnelia_signature.png") no-repeat`,
+      background: `url("${mneliaSignature.src}") no-repeat`,
       styles: {
         position: "absolute",
         bottom: "42%",

--- a/next-env.d.ts
+++ b/next-env.d.ts
@@ -2,4 +2,4 @@
 /// <reference types="next/image-types/global" />
 
 // NOTE: This file should not be edited
-// see https://nextjs.org/docs/basic-features/typescript for more information.
+// see https://nextjs.org/docs/app/building-your-application/configuring/typescript for more information.

--- a/tsconfig.json
+++ b/tsconfig.json
@@ -25,6 +25,9 @@
     "paths": {
       "@/*": [
         "./app/*"
+      ],
+      "@public/*": [
+        "./public/*"
       ]
     },
     "forceConsistentCasingInFileNames": true


### PR DESCRIPTION
This pull request converts dynamic image URL references to static imports, enabling Next.js build optimizations and proper asset caching.

Changes:
- Add `@public/*` path alias to tsconfig for importing public assets
- Replace all `APP_URL` string concatenation with static imports
- Use `.src` property from StaticImageData objects for proper URL resolution
- Update AuthPrompt, SelectableListItem, ServicePreview, and Theme components

This improves performance by allowing Next.js to hash, compress, and serve images with proper cache headers during the build process.