### PR TITLE
Fix iOS safe area handling for full-bleed iPod shell

### DIFF
--- a/app/components/Ipod/GlobalStyles.ts
+++ b/app/components/Ipod/GlobalStyles.ts
@@ -26,6 +26,12 @@ export const GlobalStyles = createGlobalStyle`
     box-sizing: border-box;
   }
 
+  @media (display-mode: standalone) {
+    body {
+      height: 100vh;
+    }
+  }
+
   @media (prefers-color-scheme: dark) {
     html {
       color-scheme: dark;

--- a/app/components/Ipod/Styled/index.ts
+++ b/app/components/Ipod/Styled/index.ts
@@ -59,7 +59,7 @@ export const ScreenContainer = styled.div`
   }
 
   ${Screen.SM.MediaQuery} {
-    margin: ${Unit.MD} ${Unit.MD} 0;
+    margin: calc(${Unit.MD} + env(safe-area-inset-top)) ${Unit.MD} 0;
   }
 `;
 


### PR DESCRIPTION
This pull fixes the iOS safe area so the iPod shell stays full-bleed while the screen content respects the notch and home indicator.

- Shifts ScreenContainer down by `env(safe-area-inset-top)` on mobile instead of padding the entire body
- Extends Shell background behind the home indicator via `padding-bottom: env(safe-area-inset-bottom)` on mobile
- Reverts body-level safe area padding in `globals.css` and `GlobalStyles.ts`