### PR TITLE
Improve Lighthouse performance scores

### DIFF
--- a/app/components/Ipod/Ipod.tsx
+++ b/app/components/Ipod/Ipod.tsx
@@ -89,7 +89,10 @@ const Ipod = ({ appleAccessToken, spotifyCallbackCode }: Props) => {
           </SpotifySDKProvider>
         </ViewContextProvider>
       </SettingsProvider>
-      <Script src="https://sdk.scdn.co/spotify-player.js" />
+      <Script
+        src="https://sdk.scdn.co/spotify-player.js"
+        strategy="lazyOnload"
+      />
     </QueryClientProvider>
   );
 };

--- a/app/layout.tsx
+++ b/app/layout.tsx
@@ -65,12 +65,19 @@ export default function RootLayout({
 }) {
   return (
     <html>
+      <head>
+        <link rel="preconnect" href="https://sdk.scdn.co" crossOrigin="" />
+        <link rel="preconnect" href="https://js-cdn.music.apple.com" crossOrigin="" />
+      </head>
       <body>
         <SerwistProvider swUrl="/ipod/serwist/sw.js" options={{ scope: "/ipod" }}>
           <StyledComponentsRegistry>{children}</StyledComponentsRegistry>
         </SerwistProvider>
       </body>
-      <Script src="https://js-cdn.music.apple.com/musickit/v3/musickit.js" />
+      <Script
+        src="https://js-cdn.music.apple.com/musickit/v3/musickit.js"
+        strategy="lazyOnload"
+      />
     </html>
   );
 }

--- a/app/sw.ts
+++ b/app/sw.ts
@@ -3,7 +3,7 @@
 /// <reference lib="webworker" />
 import { defaultCache } from "@serwist/turbopack/worker";
 import type { PrecacheEntry, SerwistGlobalConfig } from "serwist";
-import { NetworkOnly, Serwist } from "serwist";
+import { ExpirationPlugin, NetworkOnly, Serwist, StaleWhileRevalidate } from "serwist";
 
 declare global {
   interface WorkerGlobalScope extends SerwistGlobalConfig {
@@ -22,6 +22,17 @@ const serwist = new Serwist({
     {
       matcher: /\/ipod\/api\/.*/,
       handler: new NetworkOnly(),
+    },
+    {
+      matcher: ({ url }) =>
+        url.hostname === "sdk.scdn.co" ||
+        url.hostname === "js-cdn.music.apple.com",
+      handler: new StaleWhileRevalidate({
+        cacheName: "third-party-sdks",
+        plugins: [
+          new ExpirationPlugin({ maxEntries: 4, maxAgeSeconds: 60 * 60 * 24 }),
+        ],
+      }),
     },
     ...defaultCache,
   ],

--- a/next-env.d.ts
+++ b/next-env.d.ts
@@ -1,6 +1,6 @@
 /// <reference types="next" />
 /// <reference types="next/image-types/global" />
-import "./.next/dev/types/routes.d.ts";
+import "./.next/types/routes.d.ts";
 
 // NOTE: This file should not be edited
 // see https://nextjs.org/docs/app/api-reference/config/typescript for more information.

--- a/package.json
+++ b/package.json
@@ -52,6 +52,12 @@
     "serwist": "^9.5.7",
     "typescript": "npm:@typescript/typescript6"
   },
+  "browserslist": [
+    "last 2 Chrome versions",
+    "last 2 Firefox versions",
+    "last 2 Safari versions",
+    "last 2 Edge versions"
+  ],
   "pnpm": {
     "onlyBuiltDependencies": [
       "esbuild",


### PR DESCRIPTION
This pull adds preconnect hints for third-party SDK origins, defers non-critical script loading with `lazyOnload`, caches Spotify and MusicKit SDKs in the service worker using `StaleWhileRevalidate`, and narrows the browserslist to modern browsers to eliminate unnecessary polyfills.
