### PR TITLE
refactor: unify data fetcher abstraction and fix Spotify playback

### DIFF
--- a/app/hooks/audio/useAudioPlayer.tsx
+++ b/app/hooks/audio/useAudioPlayer.tsx
@@ -172,11 +172,15 @@ export const AudioPlayerProvider = ({ children }: Props) => {
       }));
 
       try {
-        // Set the shuffle mode before starting playback
+        // Best-effort: set shuffle mode before playback, but don't block play if it fails
         const shouldShuffle = shuffleMode !== "off";
-        await updateSpotifyPlayerState(
-          `shuffle?state=${shouldShuffle}&device_id=${deviceId}`
-        );
+        try {
+          await updateSpotifyPlayerState(
+            `shuffle?state=${shouldShuffle}&device_id=${deviceId}`
+          );
+        } catch {
+          // Shuffle is best-effort; don't block playback
+        }
 
         const body: { uris: string[]; offset?: { position: number } } = {
           uris,

--- a/app/hooks/musicKit/useMKDataFetcher.ts
+++ b/app/hooks/musicKit/useMKDataFetcher.ts
@@ -67,8 +67,8 @@ const useMKDataFetcher = () => {
   );
 
   const fetchAlbums = useCallback(
-    async ({ pageParam, limit }: { pageParam: number; limit: number }) => {
-      const offset = pageParam * limit;
+    async ({ pageParam, limit }: MediaApi.PaginationParams) => {
+      const offset = Number(pageParam) * limit;
 
       const response = await fetchAppleMusicApi<AppleMusicApi.AlbumResponse>({
         endpoint: `/albums`,
@@ -78,18 +78,20 @@ const useMKDataFetcher = () => {
           offset,
         },
       });
+
+      if (!response) return { data: [], nextPageParam: undefined };
+
       const nextPageParam = getNextPageParam({
         limit,
         offset,
-        prevPageParam: pageParam,
-        totalResults: response?.meta.total,
+        prevPageParam: Number(pageParam),
+        totalResults: response.meta.total,
       });
 
       return {
-        data:
-          response?.data.map((item: AppleMusicApi.Album) =>
-            ConversionUtils.convertAppleAlbum(item)
-          ) ?? [],
+        data: response.data.map((item: AppleMusicApi.Album) =>
+          ConversionUtils.convertAppleAlbum(item)
+        ),
         nextPageParam,
       };
     },
@@ -112,7 +114,7 @@ const useMKDataFetcher = () => {
 
   const fetchArtists = useCallback(
     async ({ limit, pageParam }: MediaApi.PaginationParams) => {
-      const offset = pageParam * limit;
+      const offset = Number(pageParam) * limit;
 
       const response = await fetchAppleMusicApi<AppleMusicApi.ArtistResponse>({
         endpoint: `/artists`,
@@ -122,19 +124,20 @@ const useMKDataFetcher = () => {
         },
         inLibrary: true,
       });
+
+      if (!response) return { data: [], nextPageParam: undefined };
+
       const nextPageParam = getNextPageParam({
         limit,
         offset,
-        prevPageParam: pageParam,
-        totalResults: response?.meta.total,
+        prevPageParam: Number(pageParam),
+        totalResults: response.meta.total,
       });
 
-      const result: MediaApi.PaginatedResponse<MediaApi.Artist[]> = {
-        data: response?.data.map(ConversionUtils.convertAppleArtist) ?? [],
+      return {
+        data: response.data.map(ConversionUtils.convertAppleArtist),
         nextPageParam,
       };
-
-      return result;
     },
     [fetchAppleMusicApi]
   );
@@ -155,31 +158,31 @@ const useMKDataFetcher = () => {
 
   const fetchPlaylists = useCallback(
     async ({ limit, pageParam }: MediaApi.PaginationParams) => {
-      const offset = pageParam * limit;
+      const offset = Number(pageParam) * limit;
 
       const response = await fetchAppleMusicApi<AppleMusicApi.PlaylistResponse>(
         {
           endpoint: "/playlists",
           params: {
-            limit: 50,
+            limit,
             offset,
           },
           inLibrary: true,
         }
       );
+      if (!response) return { data: [], nextPageParam: undefined };
+
       const nextPageParam = getNextPageParam({
         limit,
         offset,
-        prevPageParam: pageParam,
-        totalResults: response?.meta.total,
+        prevPageParam: Number(pageParam),
+        totalResults: response.meta.total,
       });
 
-      const result: MediaApi.PaginatedResponse<MediaApi.Playlist[]> = {
-        data: response?.data.map(ConversionUtils.convertApplePlaylist) ?? [],
+      return {
+        data: response.data.map(ConversionUtils.convertApplePlaylist),
         nextPageParam,
       };
-
-      return result;
     },
     [fetchAppleMusicApi]
   );

--- a/app/hooks/spotify/useSpotifyDataFetcher.ts
+++ b/app/hooks/spotify/useSpotifyDataFetcher.ts
@@ -18,7 +18,7 @@ const useSpotifyDataFetcher = () => {
     async ({ pageParam, limit }: MediaApi.PaginationParams) => {
       if (!accessToken) return;
 
-      const offset = pageParam * limit;
+      const offset = Number(pageParam) * limit;
 
       const response =
         await spotifyApi<SpotifyApi.UsersSavedAlbumsResponse>({
@@ -33,7 +33,7 @@ const useSpotifyDataFetcher = () => {
           response.items.map((item) =>
             ConversionUtils.convertSpotifyAlbumFull(item.album)
           ) ?? [],
-        nextPageParam: response.next ? pageParam + 1 : undefined,
+        nextPageParam: response.next ? Number(pageParam) + 1 : undefined,
       };
 
       return result;
@@ -42,7 +42,7 @@ const useSpotifyDataFetcher = () => {
   );
 
   const fetchAlbum = useCallback(
-    async ({ id }: { id: string }) => {
+    async (id: string, _inLibrary?: boolean) => {
       if (!accessToken) return;
 
       const response = await spotifyApi<SpotifyApi.SingleAlbumResponse>({
@@ -57,8 +57,10 @@ const useSpotifyDataFetcher = () => {
   );
 
   const fetchArtists = useCallback(
-    async ({ limit, after }: MediaApi.PaginationParams) => {
+    async ({ pageParam, limit }: MediaApi.PaginationParams) => {
       if (!accessToken) return;
+
+      const cursor = typeof pageParam === "string" ? pageParam : undefined;
 
       const response =
         await spotifyApi<SpotifyApi.UsersFollowedArtistsResponse>({
@@ -66,7 +68,7 @@ const useSpotifyDataFetcher = () => {
           params: {
             type: "artist",
             limit,
-            after: safeParseAfter(after),
+            after: safeParseAfter(cursor),
           },
           accessToken,
           onTokenExpired: refreshAccessToken,
@@ -79,7 +81,9 @@ const useSpotifyDataFetcher = () => {
 
       const result: MediaApi.PaginatedResponse<MediaApi.Artist[]> = {
         data,
-        after: response.artists.next ? data[data.length - 1]?.id : undefined,
+        nextPageParam: response.artists.next
+          ? data[data.length - 1]?.id
+          : undefined,
       };
 
       return result;
@@ -87,8 +91,8 @@ const useSpotifyDataFetcher = () => {
     [accessToken, refreshAccessToken]
   );
 
-  const fetchArtist = useCallback(
-    async (id: string) => {
+  const fetchArtistAlbums = useCallback(
+    async (id: string, _inLibrary?: boolean) => {
       if (!accessToken) return;
 
       const response = await spotifyApi<SpotifyApi.ArtistsAlbumsResponse>({
@@ -115,7 +119,7 @@ const useSpotifyDataFetcher = () => {
     async ({ pageParam, limit }: MediaApi.PaginationParams) => {
       if (!accessToken) return;
 
-      const offset = pageParam * limit;
+      const offset = Number(pageParam) * limit;
 
       const response =
         await spotifyApi<SpotifyApi.ListOfCurrentUsersPlaylistsResponse>({
@@ -133,7 +137,7 @@ const useSpotifyDataFetcher = () => {
 
       const result: MediaApi.PaginatedResponse<MediaApi.Playlist[]> = {
         data: resultData,
-        nextPageParam: response.next ? pageParam + 1 : undefined,
+        nextPageParam: response.next ? Number(pageParam) + 1 : undefined,
       };
 
       return result;
@@ -142,7 +146,7 @@ const useSpotifyDataFetcher = () => {
   );
 
   const fetchPlaylist = useCallback(
-    async (id: string) => {
+    async (id: string, _inLibrary?: boolean) => {
       if (!accessToken) return;
 
       const response = await spotifyApi<SpotifyApi.PlaylistObjectFull>({
@@ -180,7 +184,7 @@ const useSpotifyDataFetcher = () => {
     fetchAlbums,
     fetchAlbum,
     fetchArtists,
-    fetchArtist,
+    fetchArtistAlbums,
     fetchPlaylists,
     fetchPlaylist,
     fetchSearchResults,

--- a/app/hooks/utils/useDataFetcher.ts
+++ b/app/hooks/utils/useDataFetcher.ts
@@ -44,7 +44,34 @@ const STALE_TIME = {
   search: 60 * 1000,
 } as const;
 
-const useDataFetchers = () => {
+export interface DataFetcher {
+  fetchAlbums: (
+    params: MediaApi.PaginationParams
+  ) => Promise<MediaApi.PaginatedResponse<MediaApi.Album[]> | undefined>;
+  fetchAlbum: (
+    id: string,
+    inLibrary?: boolean
+  ) => Promise<MediaApi.Album | undefined>;
+  fetchArtists: (
+    params: MediaApi.PaginationParams
+  ) => Promise<MediaApi.PaginatedResponse<MediaApi.Artist[]> | undefined>;
+  fetchArtistAlbums: (
+    id: string,
+    inLibrary?: boolean
+  ) => Promise<MediaApi.Album[] | undefined>;
+  fetchPlaylists: (
+    params: MediaApi.PaginationParams
+  ) => Promise<MediaApi.PaginatedResponse<MediaApi.Playlist[]> | undefined>;
+  fetchPlaylist: (
+    id: string,
+    inLibrary?: boolean
+  ) => Promise<MediaApi.Playlist | undefined>;
+  fetchSearchResults: (
+    query: string
+  ) => Promise<MediaApi.SearchResults | undefined>;
+}
+
+const useResolvedFetcher = () => {
   const spotifyDataFetcher = useSpotifyDataFetcher();
   const appleDataFetcher = useMKDataFetcher();
   const { service, isAppleAuthorized, isSpotifyAuthorized } = useSettings();
@@ -54,24 +81,20 @@ const useDataFetchers = () => {
     (service === "apple" && isAppleAuthorized && isConfigured) ||
     (service === "spotify" && isSpotifyAuthorized);
 
-  return { spotifyDataFetcher, appleDataFetcher, service, enabled };
+  const fetcher: DataFetcher =
+    service === "spotify" ? spotifyDataFetcher : appleDataFetcher;
+
+  return { fetcher, enabled };
 };
 
 export const useFetchAlbum = (
   options: CommonFetcherProps & AlbumFetcherProps
 ) => {
-  const { spotifyDataFetcher, appleDataFetcher, service, enabled } =
-    useDataFetchers();
+  const { fetcher, enabled } = useResolvedFetcher();
 
   return useQuery({
     queryKey: ["album", { id: options.id }],
-    queryFn: async () => {
-      if (service === "apple") {
-        return appleDataFetcher.fetchAlbum(options.id, options.inLibrary);
-      } else if (service === "spotify") {
-        return spotifyDataFetcher.fetchAlbum({ id: options.id });
-      }
-    },
+    queryFn: () => fetcher.fetchAlbum(options.id, options.inLibrary),
     staleTime: STALE_TIME.detail,
     enabled: enabled && !options.lazy,
   });
@@ -80,123 +103,68 @@ export const useFetchAlbum = (
 export const useFetchAlbums = (
   options: CommonFetcherProps & AlbumsFetcherProps
 ) => {
-  const { spotifyDataFetcher, appleDataFetcher, service, enabled } =
-    useDataFetchers();
+  const { fetcher, enabled } = useResolvedFetcher();
 
   return useInfiniteQuery({
     queryKey: ["albums"],
-    queryFn: async ({ pageParam }) => {
-      const params = {
-        pageParam,
-        limit: 50,
-      };
-
-      if (service === "apple") {
-        return appleDataFetcher.fetchAlbums(params);
-      } else if (service === "spotify") {
-        return spotifyDataFetcher.fetchAlbums(params);
-      }
-    },
+    queryFn: ({ pageParam }) =>
+      fetcher.fetchAlbums({ pageParam, limit: 50 }),
     staleTime: STALE_TIME.library,
     enabled: enabled && !options.lazy,
     getNextPageParam: (lastPage) => lastPage?.nextPageParam,
-    initialPageParam: 0,
+    initialPageParam: 0 as number | string,
   });
 };
 
 export const useFetchArtists = (options: CommonFetcherProps) => {
-  const { spotifyDataFetcher, appleDataFetcher, service, enabled } =
-    useDataFetchers();
+  const { fetcher, enabled } = useResolvedFetcher();
 
   return useInfiniteQuery({
     queryKey: ["artists"],
-    queryFn: async ({ pageParam }) => {
-      const params = {
-        pageParam,
-        limit: 20,
-        after: `${pageParam}`,
-      };
-
-      if (service === "apple") {
-        return appleDataFetcher.fetchArtists(params);
-      } else if (service === "spotify") {
-        return spotifyDataFetcher.fetchArtists(params);
-      }
-    },
+    queryFn: ({ pageParam }) =>
+      fetcher.fetchArtists({ pageParam, limit: 20 }),
     staleTime: STALE_TIME.library,
     enabled: enabled && !options.lazy,
-    // TODO: Figure out a better way to deal with `after` param
-    getNextPageParam: (lastPage) =>
-      service === "spotify"
-        ? (lastPage?.after as any)
-        : lastPage?.nextPageParam,
-    initialPageParam: 0,
+    getNextPageParam: (lastPage) => lastPage?.nextPageParam,
+    initialPageParam: 0 as number | string,
   });
 };
 
 export const useFetchArtistAlbums = (
   options: CommonFetcherProps & ArtistFetcherProps
 ) => {
-  const { spotifyDataFetcher, appleDataFetcher, service, enabled } =
-    useDataFetchers();
+  const { fetcher, enabled } = useResolvedFetcher();
 
   return useQuery({
     queryKey: ["artistAlbums", { id: options.id }],
-    queryFn: async () => {
-      if (service === "apple") {
-        return appleDataFetcher.fetchArtistAlbums(
-          options.id,
-          options.inLibrary
-        );
-      } else if (service === "spotify") {
-        return spotifyDataFetcher.fetchArtist(options.id);
-      }
-    },
+    queryFn: () => fetcher.fetchArtistAlbums(options.id, options.inLibrary),
     staleTime: STALE_TIME.detail,
     enabled: enabled && !options.lazy,
   });
 };
 
 export const useFetchPlaylists = (options: CommonFetcherProps) => {
-  const { spotifyDataFetcher, appleDataFetcher, service, enabled } =
-    useDataFetchers();
+  const { fetcher, enabled } = useResolvedFetcher();
 
   return useInfiniteQuery({
     queryKey: ["playlists"],
-    queryFn: async ({ pageParam }) => {
-      const params = {
-        limit: 20,
-        pageParam,
-      };
-
-      if (service === "apple") {
-        return appleDataFetcher.fetchPlaylists(params);
-      } else if (service === "spotify") {
-        return spotifyDataFetcher.fetchPlaylists(params);
-      }
-    },
+    queryFn: ({ pageParam }) =>
+      fetcher.fetchPlaylists({ pageParam, limit: 20 }),
     staleTime: STALE_TIME.library,
     enabled: enabled && !options.lazy,
     getNextPageParam: (lastPage) => lastPage?.nextPageParam,
-    initialPageParam: 0,
+    initialPageParam: 0 as number | string,
   });
 };
 
 export const useFetchPlaylist = (
   options: CommonFetcherProps & PlaylistFetcherProps
 ) => {
-  const { spotifyDataFetcher, appleDataFetcher, service, enabled } =
-    useDataFetchers();
+  const { fetcher, enabled } = useResolvedFetcher();
 
   return useQuery({
     queryKey: ["playlists", { id: options.id }],
-    queryFn: async () => {
-      if (service === "apple") {
-        return appleDataFetcher.fetchPlaylist(options.id, options.inLibrary);
-      } else if (service === "spotify") {
-        return spotifyDataFetcher.fetchPlaylist(options.id);
-      }
-    },
+    queryFn: () => fetcher.fetchPlaylist(options.id, options.inLibrary),
     staleTime: STALE_TIME.detail,
     enabled: enabled && !options.lazy,
   });
@@ -205,18 +173,11 @@ export const useFetchPlaylist = (
 export const useFetchSearchResults = (
   options: CommonFetcherProps & SearchFetcherProps
 ) => {
-  const { spotifyDataFetcher, appleDataFetcher, service, enabled } =
-    useDataFetchers();
+  const { fetcher, enabled } = useResolvedFetcher();
 
   return useQuery({
     queryKey: ["search", { query: options.query }],
-    queryFn: async () => {
-      if (service === "spotify") {
-        return spotifyDataFetcher.fetchSearchResults(options.query);
-      } else if (service === "apple") {
-        return appleDataFetcher.fetchSearchResults(options.query);
-      }
-    },
+    queryFn: () => fetcher.fetchSearchResults(options.query),
     staleTime: STALE_TIME.search,
     enabled: enabled && !options.lazy,
   });

--- a/app/types/Media.API.d.ts
+++ b/app/types/Media.API.d.ts
@@ -64,14 +64,12 @@ declare namespace MediaApi {
   }
 
   interface PaginationParams {
-    pageParam: number;
+    pageParam: number | string;
     limit: number;
-    after?: string;
   }
 
   interface PaginatedResponse<TType> {
     data: TType;
-    nextPageParam?: number;
-    after?: string;
+    nextPageParam?: number | string;
   }
 }

--- a/app/utils/spotifyApi.ts
+++ b/app/utils/spotifyApi.ts
@@ -53,8 +53,11 @@ async function executeRequest<T>(
     );
   }
 
-  // Some Spotify endpoints (e.g. PUT /me/player/*) return 204 with no body
-  if (response.status === 204) {
+  const contentType = response.headers.get("content-type");
+  if (
+    response.status === 204 ||
+    !contentType?.includes("application/json")
+  ) {
     return undefined as T;
   }
 


### PR DESCRIPTION
This pull request eliminates repeated service branching in the data fetcher layer and fixes a bug where Spotify playback would always resume the last-played track instead of the selected song.

- Defines a shared `DataFetcher` interface and resolves a single fetcher based on the active service, removing 7x repeated if/else branching in `useDataFetcher.ts`
- Normalizes Spotify's cursor-based artist pagination into the shared `nextPageParam` model, removing the special-case `getNextPageParam` branch
- Renames Spotify's `fetchArtist` to `fetchArtistAlbums` and unifies method signatures across both fetchers
- Fixes `spotifyApi.ts` to check `Content-Type` header before parsing JSON (was crashing on non-JSON 200 responses from player endpoints)
- Makes the pre-play shuffle call best-effort so transient Spotify API failures don't block song playback
- Fixes Apple Music `fetchPlaylists` using hardcoded `limit: 50` instead of the passed-in value
- Adds undefined response guards in Apple Music paginated fetchers to prevent infinite pagination