### PR TITLE
fix: harden auth flow, cookie storage, and misc cleanup

### DIFF
--- a/app/api/spotify/login/route.ts
+++ b/app/api/spotify/login/route.ts
@@ -1,6 +1,7 @@
 import { SPOTIFY_CLIENT_ID } from "@/utils/constants/api";
 import { getSpotifyRedirectUri } from "@/api/spotify/utils";
 import { v4 as uuid } from "uuid";
+import { redirect } from "next/navigation";
 
 export async function GET() {
   const scope =
@@ -11,12 +12,10 @@ export async function GET() {
   const state: string = uuid();
 
   if (!redirect_uri || !client_id) {
-    const errorMessage =
-      "Missing Spotify redirect URI. Check that the Vercel ENV variables have ben properly initialized.";
-
-    return new Response(errorMessage, {
-      status: 400,
-    });
+    return new Response(
+      "Missing Spotify client ID or redirect URI. Check that the Vercel ENV variables have been properly initialized.",
+      { status: 400 }
+    );
   }
 
   const authParams = new URLSearchParams({
@@ -27,12 +26,5 @@ export async function GET() {
     state,
   }).toString();
 
-  return new Response(
-    JSON.stringify({
-      message: `https://accounts.spotify.com/authorize/?${authParams}`,
-    }),
-    {
-      status: 200,
-    }
-  );
+  redirect(`https://accounts.spotify.com/authorize/?${authParams}`);
 }

--- a/app/api/spotify/utils.ts
+++ b/app/api/spotify/utils.ts
@@ -35,27 +35,43 @@ export const getSpotifyAuthorizationHeader = (
 };
 
 export const setSpotifyTokens = async (accessToken: string, refreshToken: string) => {
-  const tokenRefreshTimestamp = Date.now().toString();
+  const value = JSON.stringify({
+    accessToken,
+    refreshToken,
+    lastRefreshedTimestamp: Date.now(),
+  });
 
-  await setCookie(
-    SPOTIFY_TOKENS_COOKIE_NAME,
-    `${accessToken},${refreshToken},${tokenRefreshTimestamp}`,
-    { cookies }
-  );
+  await setCookie(SPOTIFY_TOKENS_COOKIE_NAME, value, { cookies });
 };
 
 export const getSpotifyTokens = async () => {
-  const spotifyTokens = await getCookie(SPOTIFY_TOKENS_COOKIE_NAME, {
-    cookies,
-  });
-  const [storedAccessToken, storedRefreshToken, lastRefreshedTimestamp] =
-    spotifyTokens?.split(",") ?? [undefined, undefined, undefined];
+  const raw = await getCookie(SPOTIFY_TOKENS_COOKIE_NAME, { cookies });
 
-  return {
-    storedAccessToken,
-    storedRefreshToken,
-    lastRefreshedTimestamp: parseInt(lastRefreshedTimestamp ?? "") || undefined,
-  };
+  if (!raw) {
+    return {
+      storedAccessToken: undefined,
+      storedRefreshToken: undefined,
+      lastRefreshedTimestamp: undefined,
+    };
+  }
+
+  try {
+    const parsed = JSON.parse(raw);
+    return {
+      storedAccessToken: parsed.accessToken as string | undefined,
+      storedRefreshToken: parsed.refreshToken as string | undefined,
+      lastRefreshedTimestamp: parsed.lastRefreshedTimestamp as number | undefined,
+    };
+  } catch {
+    // Handle legacy comma-delimited format during migration
+    const [storedAccessToken, storedRefreshToken, lastRefreshedTimestamp] =
+      raw.split(",");
+    return {
+      storedAccessToken,
+      storedRefreshToken,
+      lastRefreshedTimestamp: parseInt(lastRefreshedTimestamp ?? "") || undefined,
+    };
+  }
 };
 
 export const clearSpotifyTokens = async () => {

--- a/app/hooks/spotify/useSpotifyDataFetcher.ts
+++ b/app/hooks/spotify/useSpotifyDataFetcher.ts
@@ -81,7 +81,7 @@ const useSpotifyDataFetcher = () => {
 
       const result: MediaApi.PaginatedResponse<MediaApi.Artist[]> = {
         data,
-        nextPageParam: response.artists.next
+        nextPageParam: response.artists?.next
           ? data[data.length - 1]?.id
           : undefined,
       };
@@ -129,14 +129,11 @@ const useSpotifyDataFetcher = () => {
           onTokenExpired: refreshAccessToken,
         });
 
-      const resultData = await Promise.all(
-        response.items?.map(
-          ConversionUtils.convertSpotifyPlaylistSimplified
-        ) ?? []
-      );
-
       const result: MediaApi.PaginatedResponse<MediaApi.Playlist[]> = {
-        data: resultData,
+        data:
+          response.items?.map(
+            ConversionUtils.convertSpotifyPlaylistSimplified
+          ) ?? [],
         nextPageParam: response.next ? Number(pageParam) + 1 : undefined,
       };
 

--- a/app/hooks/spotify/useSpotifySDK.tsx
+++ b/app/hooks/spotify/useSpotifySDK.tsx
@@ -4,7 +4,6 @@ import { useViewContext } from "@/hooks";
 import * as SpotifyUtils from "@/utils/spotify";
 
 import { useSettings } from "..";
-import { API_URL } from "@/utils/constants/api";
 import {
   SpotifySDKContext,
   SpotifySDKState,
@@ -51,11 +50,7 @@ export const useSpotifySDK = ({
    */
   const signIn = useCallback(async () => {
     if (!isSpotifyAuthorized) {
-      // Generate the Spotify OAuth login URL with the client ID, state, scope, and redirect URI.
-      const res = await fetch(`${API_URL}/spotify/login`);
-      const spotifyLoginUrl = (await res.json()).message;
-
-      window.open(spotifyLoginUrl, "_self");
+      window.location.href = `/ipod/api/spotify/login`;
     } else if (!state.isPlayerConnected) {
       showPopup({
         id: "spotifyNotSupported",
@@ -75,6 +70,7 @@ export const useSpotifySDK = ({
   }, [isSpotifyAuthorized, setService, showPopup, state.isPlayerConnected]);
 
   const signOut = useCallback(async () => {
+    state.spotifyPlayer?.removeListener("playback_error");
     state.spotifyPlayer?.disconnect();
     setIsSpotifyAuthorized(false);
 

--- a/app/providers/SpotifySdkProvider.tsx
+++ b/app/providers/SpotifySdkProvider.tsx
@@ -36,12 +36,25 @@ export const SpotifySDKProvider = ({ children }: Props) => {
   const [isSdkReady, setIsSdkReady] = useState(false);
   const [hasError, setHasError] = useState(false);
 
-  const [storedAccessToken, storedRefreshToken, tokenLastRefreshedTimestamp] =
-    getCookie(SPOTIFY_TOKENS_COOKIE_NAME)?.split(",") ?? [
-      undefined,
-      undefined,
-      undefined,
-    ];
+  const cookieValue = getCookie(SPOTIFY_TOKENS_COOKIE_NAME);
+  let storedAccessToken: string | undefined;
+  let storedRefreshToken: string | undefined;
+  let tokenLastRefreshedTimestamp: string | undefined;
+
+  if (cookieValue) {
+    try {
+      const parsed = JSON.parse(cookieValue);
+      storedAccessToken = parsed.accessToken;
+      storedRefreshToken = parsed.refreshToken;
+      tokenLastRefreshedTimestamp = parsed.lastRefreshedTimestamp?.toString();
+    } catch {
+      // Handle legacy comma-delimited format during migration
+      const parts = cookieValue.split(",");
+      storedAccessToken = parts[0];
+      storedRefreshToken = parts[1];
+      tokenLastRefreshedTimestamp = parts[2];
+    }
+  }
 
   const [accessToken, setAccessToken] = useState<string | undefined>(
     storedAccessToken
@@ -131,10 +144,13 @@ export const SpotifySDKProvider = ({ children }: Props) => {
     } = await SpotifyUtils.getRefreshedSpotifyTokens(storedRefreshToken);
 
     if (updatedAccessToken && updatedRefreshToken) {
-      const tokenRefreshTimestamp = Date.now().toString();
       setCookie(
         SPOTIFY_TOKENS_COOKIE_NAME,
-        `${updatedAccessToken},${updatedRefreshToken},${tokenRefreshTimestamp}`
+        JSON.stringify({
+          accessToken: updatedAccessToken,
+          refreshToken: updatedRefreshToken,
+          lastRefreshedTimestamp: Date.now(),
+        })
       );
     }
     setAccessToken(updatedAccessToken);

--- a/app/utils/conversion.ts
+++ b/app/utils/conversion.ts
@@ -1,3 +1,5 @@
+import { decode as decodeHtmlEntities } from "he";
+
 // Artwork Conversion
 
 /** Accepts a url with '{w}' and '{h}' and replaces them with the specified size */
@@ -60,37 +62,30 @@ export const convertApplePlaylist = (
   songs: data.relationships?.tracks?.data.map(convertAppleSong) ?? [],
 });
 
-export const convertSpotifyPlaylistSimplified = async (
+export const convertSpotifyPlaylistSimplified = (
   data: SpotifyApi.PlaylistObjectSimplified
-): Promise<MediaApi.Playlist> => {
-  let decodedDescription = "";
-  if (data.description) {
-    const { decode } = await import("he");
-    decodedDescription = decode(data.description);
-  }
-  return {
-    id: data.id,
-    name: data.name,
-    curatorName: data.owner.display_name ?? "",
-    url: data.uri,
-    artwork: { url: data.images[0]?.url ?? "" },
-    description: decodedDescription,
-    songs: [],
-  };
-};
+): MediaApi.Playlist => ({
+  id: data.id,
+  name: data.name,
+  curatorName: data.owner.display_name ?? "",
+  url: data.uri,
+  artwork: { url: data.images[0]?.url ?? "" },
+  description: data.description ? decodeHtmlEntities(data.description) : "",
+  songs: [],
+});
 
 export const convertSpotifyPlaylistFull = (
   data: SpotifyApi.PlaylistObjectFull
 ): MediaApi.Playlist => ({
-  id: data.uri,
+  id: data.id,
   name: data.name,
   curatorName: data.owner.display_name ?? "",
   url: data.uri,
   artwork: { url: data.images[0]?.url ?? "" },
   description: data.description ?? "",
   songs: data.tracks.items
-    .filter((item) => !!item)
-    .map((item) => convertSpotifySongFull(item.track!)),
+    .filter((item): item is SpotifyApi.PlaylistTrackObject & { track: SpotifyApi.TrackObjectFull } => !!item?.track)
+    .map((item) => convertSpotifySongFull(item.track)),
 });
 
 export const convertAppleAlbum = (
@@ -191,19 +186,15 @@ export const convertSpotifyMediaItem = (
   };
 };
 
-export const convertSpotifySearchResults = async (
+export const convertSpotifySearchResults = (
   results: SpotifyApi.SearchResponse
-): Promise<MediaApi.SearchResults> => {
-  const playlists = await Promise.all(
-    results.playlists?.items.map(convertSpotifyPlaylistSimplified) ?? []
-  );
-  return {
-    artists: results.artists?.items.map(convertSpotifyArtistFull) ?? [],
-    albums: results.albums?.items.map(convertSpotifyAlbumSimplified) ?? [],
-    songs: results.tracks?.items.map(convertSpotifySongFull) ?? [],
-    playlists,
-  };
-};
+): MediaApi.SearchResults => ({
+  artists: results.artists?.items.map(convertSpotifyArtistFull) ?? [],
+  albums: results.albums?.items.map(convertSpotifyAlbumSimplified) ?? [],
+  songs: results.tracks?.items.map(convertSpotifySongFull) ?? [],
+  playlists:
+    results.playlists?.items.map(convertSpotifyPlaylistSimplified) ?? [],
+});
 
 export const convertAppleSearchResults = (
   search: AppleMusicApi.SearchResponse


### PR DESCRIPTION
This pull hardens the Spotify auth flow, fixes cookie storage fragility, and cleans up several minor issues caught during code review.

- Changes `/api/spotify/login` to return a 302 redirect instead of JSON, eliminating an extra fetch round trip during OAuth sign-in
- Uses JSON for the Spotify token cookie instead of a comma-delimited string, with a legacy format fallback for seamless migration
- Static-imports the `he` library instead of dynamic-importing it per playlist conversion, making `convertSpotifyPlaylistSimplified` and `convertSpotifySearchResults` synchronous and removing unnecessary `Promise.all` wrappers
- Fixes unsafe `item.track!` non-null assertion in `convertSpotifyPlaylistFull` with a type-safe filter
- Fixes inconsistent playlist ID mapping (`data.uri` -> `data.id`)
- Adds missing optional chaining on `response.artists?.next` in `fetchArtists`
- Removes `playback_error` listener before `disconnect()` to prevent error overlay on sign-out
- Fixes misleading error message and typo in login route