### PR TITLE
Migrate environment variables to Cloudflare Secrets Store

### DIFF
--- a/app/api/spotify/callback/route.ts
+++ b/app/api/spotify/callback/route.ts
@@ -1,4 +1,4 @@
-import { SPOTIFY_CLIENT_ID, SPOTIFY_CLIENT_SECRET } from "@/utils/constants/api";
+import { getSpotifyClientId, getSpotifyClientSecret } from "@/utils/constants/api";
 import { getSpotifyRedirectUri, setSpotifyTokens } from "@/api/spotify/utils";
 import { NextRequest } from "next/server";
 
@@ -11,8 +11,11 @@ export async function GET(req: NextRequest) {
     });
   }
 
+  const clientId = await getSpotifyClientId();
+  const clientSecret = await getSpotifyClientSecret();
+
   const base64Auth = Buffer.from(
-    `${SPOTIFY_CLIENT_ID}:${SPOTIFY_CLIENT_SECRET}`
+    `${clientId}:${clientSecret}`
   ).toString("base64");
 
   try {

--- a/app/api/spotify/login/route.ts
+++ b/app/api/spotify/login/route.ts
@@ -1,4 +1,4 @@
-import { SPOTIFY_CLIENT_ID } from "@/utils/constants/api";
+import { getSpotifyClientId } from "@/utils/constants/api";
 import { getSpotifyRedirectUri } from "@/api/spotify/utils";
 import { v4 as uuid } from "uuid";
 import { redirect } from "next/navigation";
@@ -8,12 +8,12 @@ export async function GET() {
     "user-read-private user-read-email user-library-read user-follow-read playlist-read-collaborative playlist-read-private streaming user-read-playback-state user-read-currently-playing user-modify-playback-state";
 
   const redirect_uri = getSpotifyRedirectUri();
-  const client_id = SPOTIFY_CLIENT_ID;
+  const client_id = await getSpotifyClientId();
   const state: string = uuid();
 
   if (!redirect_uri || !client_id) {
     return new Response(
-      "Missing Spotify client ID or redirect URI. Check that the Vercel ENV variables have been properly initialized.",
+      "Missing Spotify client ID or redirect URI. Check that the environment variables have been properly initialized.",
       { status: 400 }
     );
   }

--- a/app/api/spotify/refresh/route.ts
+++ b/app/api/spotify/refresh/route.ts
@@ -1,4 +1,4 @@
-import { SPOTIFY_CLIENT_ID, SPOTIFY_CLIENT_SECRET } from "@/utils/constants/api";
+import { getSpotifyClientId, getSpotifyClientSecret } from "@/utils/constants/api";
 import { getSpotifyTokens, setSpotifyTokens } from "@/api/spotify/utils";
 import { NextResponse } from "next/server";
 
@@ -20,8 +20,11 @@ export async function GET() {
     refresh_token: storedRefreshToken,
   });
 
+  const clientId = await getSpotifyClientId();
+  const clientSecret = await getSpotifyClientSecret();
+
   const base64EncodedAuthorizationHeader = Buffer.from(
-    `${SPOTIFY_CLIENT_ID}:${SPOTIFY_CLIENT_SECRET}`
+    `${clientId}:${clientSecret}`
   ).toString("base64");
 
   try {

--- a/app/page.tsx
+++ b/app/page.tsx
@@ -1,11 +1,11 @@
 import { Suspense } from "react";
 import { Ipod } from "@/components/Ipod";
-import { APPLE_DEVELOPER_TOKEN } from "@/utils/constants/api";
+import { getAppleDeveloperToken } from "@/utils/constants/api";
 
-export const revalidate = 3600;
+export const dynamic = "force-dynamic";
 
-export default function Page() {
-  const appleAccessToken = APPLE_DEVELOPER_TOKEN ?? "";
+export default async function Page() {
+  const appleAccessToken = (await getAppleDeveloperToken()) ?? "";
 
   return (
     <Suspense>

--- a/app/utils/constants/api.ts
+++ b/app/utils/constants/api.ts
@@ -1,10 +1,22 @@
+import { getCloudflareContext } from "@opennextjs/cloudflare";
+
 export const APP_URL = "/ipod";
 export const API_URL = `${APP_URL}/api`;
 
-export const SPOTIFY_CLIENT_ID = process.env.SPOTIFY_CLIENT_ID;
-export const SPOTIFY_CLIENT_SECRET = process.env.SPOTIFY_CLIENT_SECRET;
 export const SPOTIFY_TOKENS_COOKIE_NAME = "ipod-spotify-tokens";
-
 export const DEFAULT_ARTWORK_URL = `${APP_URL}/default_album_artwork.png`;
 
-export const APPLE_DEVELOPER_TOKEN = process.env.APPLE_DEVELOPER_TOKEN;
+export async function getSpotifyClientId() {
+  const { env } = await getCloudflareContext({ async: true });
+  return (env as any).SPOTIFY_CLIENT_ID.get() as Promise<string>;
+}
+
+export async function getSpotifyClientSecret() {
+  const { env } = await getCloudflareContext({ async: true });
+  return (env as any).SPOTIFY_CLIENT_SECRET.get() as Promise<string>;
+}
+
+export async function getAppleDeveloperToken() {
+  const { env } = await getCloudflareContext({ async: true });
+  return (env as any).APPLE_DEVELOPER_TOKEN.get() as Promise<string>;
+}

--- a/wrangler.jsonc
+++ b/wrangler.jsonc
@@ -23,5 +23,22 @@
 		// Enable image optimization
 		// see https://opennext.js.org/cloudflare/howtos/image
 		"binding": "IMAGES"
-	}
+	},
+	"secrets_store_secrets": [
+		{
+			"binding": "SPOTIFY_CLIENT_ID",
+			"store_id": "7a6d5ee5bc7e423689d27f9b512b6ada",
+			"secret_name": "SPOTIFY_CLIENT_ID"
+		},
+		{
+			"binding": "SPOTIFY_CLIENT_SECRET",
+			"store_id": "7a6d5ee5bc7e423689d27f9b512b6ada",
+			"secret_name": "SPOTIFY_CLIENT_SECRET"
+		},
+		{
+			"binding": "APPLE_DEVELOPER_TOKEN",
+			"store_id": "7a6d5ee5bc7e423689d27f9b512b6ada",
+			"secret_name": "APPLE_DEVELOPER_TOKEN"
+		}
+	]
 }


### PR DESCRIPTION
This pull request migrates hardcoded process.env references for Spotify and Apple Music credentials to use Cloudflare's Secrets Store via getCloudflareContext({ async: true })

- Adds secrets_store_secrets bindings to wrangler.jsonc
- Converts static env var exports to async getter functions
- Updates all API routes and the main page to await secret values at runtime
- Marks the root page as force-dynamic to ensure runtime secret access